### PR TITLE
add support for a comment of a trailing line of a query

### DIFF
--- a/__tests__/integration/error_parsing.test.ts
+++ b/__tests__/integration/error_parsing.test.ts
@@ -52,7 +52,30 @@ describe('error', () => {
       })
       .catch((e: ClickHouseError) => {
         expect(e.message).to.be.a('string');
-        expect(e.message).to.match(/failed at position 15/);
+        expect(e.message).to.match(/failed at position/);
+        expect(e.message).to.have.lengthOf.above(0);
+
+        expect(e.code).to.equal('62');
+        expect(e.type).to.equal('SYNTAX_ERROR');
+        done();
+      });
+  });
+
+  it('returns "syntax error" error in a multiline query', (done) => {
+    client = createClient();
+    client
+      .select({
+        query: `
+        SELECT *
+        /* This is:
+         a multiline comment
+        */
+        FRON unknown_table
+        `,
+      })
+      .catch((e: ClickHouseError) => {
+        expect(e.message).to.be.a('string');
+        expect(e.message).to.match(/failed at position/);
         expect(e.message).to.have.lengthOf.above(0);
 
         expect(e.code).to.equal('62');

--- a/__tests__/integration/select.test.ts
+++ b/__tests__/integration/select.test.ts
@@ -5,8 +5,8 @@ import {
   type ClickHouseClient,
   type Row,
   type ClickHouseError,
+  type ResponseJSON,
 } from '../../src';
-import type { ResponseJSON } from '../../src/clickhouse_types';
 
 async function rowsValues(stream: Stream.Readable): Promise<any[]> {
   const result: any[] = [];
@@ -77,6 +77,21 @@ describe('select', () => {
 
     const response = await rows.text();
     expect(response).to.equal('0\n1\n');
+  });
+
+  it('can send a query with a trailing comment', async () => {
+    client = createClient();
+    const rows = await client.select({
+      query: `
+        SELECT number
+        FROM system.numbers
+        LIMIT 2
+        -- comment`,
+      format: 'JSON',
+    });
+
+    const response = await rows.json<ResponseJSON<{ number: string }>>();
+    expect(response.data).to.deep.equal([{ number: '0' }, { number: '1' }]);
   });
 
   it('can specify settings in select', async () => {

--- a/__tests__/unit/parse_error.ts
+++ b/__tests__/unit/parse_error.ts
@@ -1,0 +1,29 @@
+import { expect } from 'chai';
+import { parseError, ClickHouseError } from '../../src/error';
+
+describe('parseError', () => {
+  it('parses a single line error', () => {
+    const message = `Code: 62.DB::Exception: Syntax error: failed at position 15 ('unknown_table') (line 1, col 15): unknown_table FORMAT JSON. Expected alias cannot be here. (SYNTAX_ERROR) (version 22.7.1.2484 (official build))`;
+    const error = parseError(message) as ClickHouseError;
+
+    expect(error).to.be.instanceof(ClickHouseError);
+    expect(error.code).to.equal('62');
+    expect(error.type).to.equal('SYNTAX_ERROR');
+    expect(error.message).to.equal(
+      `Syntax error: failed at position 15 ('unknown_table') (line 1, col 15): unknown_table FORMAT JSON. Expected alias cannot be here. `
+    );
+  });
+
+  it('parses a multiline error', () => {
+    const message = `Code: 62.DB::Exception: Syntax error: failed at position 15 ('unknown_table') (line 1, col 15): unknown_table
+    FORMAT JSON. Expected alias cannot be here. (SYNTAX_ERROR) (version 22.7.1.2484 (official build))`;
+    const error = parseError(message) as ClickHouseError;
+
+    expect(error).to.be.instanceof(ClickHouseError);
+    expect(error.code).to.equal('62');
+    expect(error.type).to.equal('SYNTAX_ERROR');
+    expect(error.message).to
+      .equal(`Syntax error: failed at position 15 ('unknown_table') (line 1, col 15): unknown_table
+    FORMAT JSON. Expected alias cannot be here. `);
+  });
+});

--- a/src/client.ts
+++ b/src/client.ts
@@ -173,7 +173,7 @@ export function validateSelectQuery(query: string): void {
 
 function formatSelectQuery(query: string, format: DataFormat): string {
   query = query.trim();
-  return query + ' FORMAT ' + format;
+  return query + ' \nFORMAT ' + format;
 }
 
 function validateInsertValues(

--- a/src/error/parse_error.ts
+++ b/src/error/parse_error.ts
@@ -1,5 +1,5 @@
 const errorRe =
-  /(Code|Error): (?<code>\d+).*Exception: (?<message>.+?)\((?<type>\w+?)\)/m;
+  /(Code|Error): (?<code>\d+).*Exception: (?<message>.+?)\((?<type>\w+?)\)/is;
 interface ParsedClickHouseError {
   message: string;
   code: string;


### PR DESCRIPTION
A query might contain a comment on the last line. The client must ensure it doesn't break a query by adding a `FORMAT ...` statement. 