### PR TITLE
fix JSON streaming parsing

### DIFF
--- a/__tests__/integration/select.test.ts
+++ b/__tests__/integration/select.test.ts
@@ -284,11 +284,11 @@ describe('select', () => {
         const rows = await rowsValues(result.asStream())
 
         expect(rows).toEqual([
-          [{ number: '0' }],
-          [{ number: '1' }],
-          [{ number: '2' }],
-          [{ number: '3' }],
-          [{ number: '4' }],
+          { number: '0' },
+          { number: '1' },
+          { number: '2' },
+          { number: '3' },
+          { number: '4' },
         ])
       })
 
@@ -301,11 +301,11 @@ describe('select', () => {
         const rows = await rowsValues(result.asStream())
 
         expect(rows).toEqual([
-          [{ number: '0' }],
-          [{ number: '1' }],
-          [{ number: '2' }],
-          [{ number: '3' }],
-          [{ number: '4' }],
+          { number: '0' },
+          { number: '1' },
+          { number: '2' },
+          { number: '3' },
+          { number: '4' },
         ])
       })
 
@@ -317,7 +317,7 @@ describe('select', () => {
 
         const rows = await rowsValues(result.asStream())
 
-        expect(rows).toEqual([[['0']], [['1']], [['2']], [['3']], [['4']]])
+        expect(rows).toEqual([['0'], ['1'], ['2'], ['3'], ['4']])
       })
 
       it('returns stream of objects in JSONCompactEachRowWithNames format', async () => {
@@ -328,14 +328,7 @@ describe('select', () => {
 
         const rows = await rowsValues(result.asStream())
 
-        expect(rows).toEqual([
-          [['number']],
-          [['0']],
-          [['1']],
-          [['2']],
-          [['3']],
-          [['4']],
-        ])
+        expect(rows).toEqual([['number'], ['0'], ['1'], ['2'], ['3'], ['4']])
       })
 
       it('returns stream of objects in JSONCompactEachRowWithNamesAndTypes format', async () => {
@@ -347,13 +340,13 @@ describe('select', () => {
         const rows = await rowsValues(result.asStream())
 
         expect(rows).toEqual([
-          [['number']],
-          [['UInt64']],
-          [['0']],
-          [['1']],
-          [['2']],
-          [['3']],
-          [['4']],
+          ['number'],
+          ['UInt64'],
+          ['0'],
+          ['1'],
+          ['2'],
+          ['3'],
+          ['4'],
         ])
       })
 
@@ -365,14 +358,7 @@ describe('select', () => {
 
         const rows = await rowsValues(result.asStream())
 
-        expect(rows).toEqual([
-          [['number']],
-          [['0']],
-          [['1']],
-          [['2']],
-          [['3']],
-          [['4']],
-        ])
+        expect(rows).toEqual([['number'], ['0'], ['1'], ['2'], ['3'], ['4']])
       })
 
       it('returns stream of objects in JSONCompactStringsEachRowWithNamesAndTypes format', async () => {
@@ -384,13 +370,13 @@ describe('select', () => {
         const rows = await rowsValues(result.asStream())
 
         expect(rows).toEqual([
-          [['number']],
-          [['UInt64']],
-          [['0']],
-          [['1']],
-          [['2']],
-          [['3']],
-          [['4']],
+          ['number'],
+          ['UInt64'],
+          ['0'],
+          ['1'],
+          ['2'],
+          ['3'],
+          ['4'],
         ])
       })
     })

--- a/__tests__/utils/test_logger.ts
+++ b/__tests__/utils/test_logger.ts
@@ -3,15 +3,19 @@ import type { Logger } from '../../src'
 export class TestLogger implements Logger {
   constructor(readonly enabled: boolean = true) {}
   debug(message: string) {
+    if (!this.enabled) return
     console.debug(`[DEBUG] ${message}`)
   }
   info(message: string) {
+    if (!this.enabled) return
     console.info(`[INFO] ${message}`)
   }
   warning(message: string) {
+    if (!this.enabled) return
     console.warn(`[WARN] ${message}`)
   }
   error(message: string) {
+    if (!this.enabled) return
     console.error(`[DEBUG] ${message}`)
   }
 }

--- a/src/result.ts
+++ b/src/result.ts
@@ -49,14 +49,12 @@ export class Rows {
    * The method will throw if called on a response in non-streamable format.
    */
   asStream(): Stream.Readable {
-    const format = this.format
-    validateStreamFormat(format)
+    validateStreamFormat(this.format)
 
     return Stream.pipeline(
       this.stream,
-      split(function (this: Stream.Transform, row: string) {
-        return new Row(row, format)
-      }),
+      // only JSON-based format are supported at the moment
+      split((row: string) => new Row(row, 'JSON')),
       function pipelineCb(err) {
         if (err) {
           console.error(err)

--- a/src/schema/table.ts
+++ b/src/schema/table.ts
@@ -91,7 +91,7 @@ export class Table<S extends Shape> {
     async function* asyncGenerator() {
       for await (const row of stream) {
         const value = (row as Row).json() as unknown[]
-        yield value[0] as Infer<S> // FIXME why we have an array here?
+        yield value as Infer<S>
       }
     }
 


### PR DESCRIPTION
The problem happened due to an unnecessary JSON-streaming parsing in Row. I fixed it by pinning `JSON` format for all JSON-based streaming formats
```
split(function (this: Stream.Transform, row: string) {
  return new Row(row, format)
}),
```

