### PR TITLE
Test all common and complex data types (minus Nested)

### DIFF
--- a/__tests__/integration/data_types.test.ts
+++ b/__tests__/integration/data_types.test.ts
@@ -1,0 +1,488 @@
+import type { ClickHouseClient } from '../../src'
+import { createTable, createTestClient, guid, TestEnv } from '../utils'
+import { v4 } from 'uuid'
+import { randomInt } from 'crypto'
+import Stream from 'stream'
+
+describe('data types', () => {
+  let client: ClickHouseClient
+  beforeEach(() => {
+    client = createTestClient()
+  })
+  afterEach(async () => {
+    await client.close()
+  })
+
+  describe('primitives', () => {
+    it('should work with integer types', async () => {
+      const values = [
+        {
+          i1: 127,
+          i2: 32767,
+          i3: 2147483647,
+          i4: '9223372036854775807',
+          i5: '170141183460469231731687303715884105727',
+          i6: '57896044618658097711785492504343953926634992332820282019728792003956564819967',
+          u1: 255,
+          u2: 65535,
+          u3: 4294967295,
+          u4: '18446744073709551615',
+          u5: '340282366920938463463374607431768211455',
+          u6: '115792089237316195423570985008687907853269984665640564039457584007913129639935',
+        },
+        {
+          i1: -128,
+          i2: -32768,
+          i3: -2147483648,
+          i4: '-9223372036854775808',
+          i5: '-170141183460469231731687303715884105728',
+          i6: '-57896044618658097711785492504343953926634992332820282019728792003956564819968',
+          u1: 120,
+          u2: 1234,
+          u3: 51234,
+          u4: '421342',
+          u5: '15324355',
+          u6: '41345135123432',
+        },
+      ]
+      const table = await createTableWithFields(
+        'u1 UInt8, u2 UInt16, u3 UInt32, u4 UInt64, u5 UInt128, u6 UInt256, ' +
+          'i1 Int8, i2 Int16, i3 Int32, i4 Int64, i5 Int128, i6 Int256'
+      )
+      await insertAndAssert(table, values)
+    })
+
+    it('should work with floating point types', async () => {
+      const values = [
+        { f1: 1.234, f2: 3.35245141223232 },
+        { f1: -0.7968956, f2: -0.113259394344324 },
+      ]
+      const table = await createTableWithFields('f1 Float32, f2 Float64')
+      await insertAndAssert(table, values)
+    })
+
+    it('should work with boolean', async () => {
+      const values = [{ b: true }, { b: false }]
+      const table = await createTableWithFields('b Boolean')
+      await insertAndAssert(table, values)
+    })
+
+    it('should work with strings', async () => {
+      const values = [
+        { s: 'foo', fs: 'bar' },
+        { s: 'qaz', fs: 'qux' },
+      ]
+      const table = await createTableWithFields('s String, fs FixedString(3)')
+      await insertAndAssert(table, values)
+    })
+
+    it('should throw if a value is too large for a FixedString field', async () => {
+      const table = await createTableWithFields('fs FixedString(3)')
+      await expect(
+        client.insert({
+          table,
+          values: [{ fs: 'foobar' }],
+          format: 'JSONEachRow',
+        })
+      ).rejects.toEqual(
+        expect.objectContaining({
+          message: expect.stringContaining(
+            'Too large value for FixedString(3)'
+          ),
+        })
+      )
+    })
+
+    // FIXME (?) does not work with JSON* insert formats, only raw streaming
+    //   as decimals are required to be passed as numbers
+    //   when using JSONEachRow (why?)
+    it('should work with decimals', async () => {
+      const stream = new Stream.Readable({
+        objectMode: false,
+        read() {
+          //
+        },
+      })
+      const row1 =
+        '1\t1234567.89\t123456789123456.789\t' +
+        '1234567891234567891234567891.1234567891\t' +
+        '12345678912345678912345678911234567891234567891234567891.12345678911234567891\n'
+      const row2 =
+        '2\t12.01\t5000000.405\t1.0000000004\t42.00000000000000013007\n'
+      stream.push(row1)
+      stream.push(row2)
+      stream.push(null)
+      const table = await createTableWithFields(
+        'd1 Decimal(9, 2), d2 Decimal(18, 3), ' +
+          'd3 Decimal(38, 10), d4 Decimal(76, 20)'
+      )
+      await client.insert({
+        table,
+        values: stream,
+        format: 'TabSeparated',
+      })
+      const result = await client
+        .select({
+          query: `SELECT * FROM ${table} ORDER BY id ASC`,
+          format: 'TabSeparated',
+        })
+        .then((r) => r.text())
+      expect(result).toEqual(row1 + row2)
+    })
+
+    it('should work with UUID', async () => {
+      const values = [{ u: v4() }, { u: v4() }]
+      const table = await createTableWithFields('u UUID')
+      await insertAndAssert(table, values)
+    })
+
+    it('should work with dates', async () => {
+      const values = [
+        {
+          d1: '2149-06-06',
+          d2: '2178-04-16',
+          dt1: '2106-02-07 06:28:15',
+          dt2: '2106-02-07 06:28:15.123',
+          dt3: '2106-02-07 06:28:15.123456',
+          dt4: '2106-02-07 06:28:15.123456789',
+        },
+        {
+          d1: '2022-09-01',
+          d2: '2007-01-29',
+          dt1: '2022-09-01 01:40:42',
+          dt2: '2021-10-02 03:12:42.123',
+          dt3: '2022-12-15 07:10:42.123456',
+          dt4: '2008-04-05 03:45:42.123456789',
+        },
+      ]
+      const table = await createTableWithFields(
+        'd1 Date, d2 Date32, dt1 DateTime, ' +
+          'dt2 DateTime64(3), dt3 DateTime64(6), dt4 DateTime64(9),'
+      )
+      await insertAndAssert(table, values)
+    })
+
+    it('should work with enums', async () => {
+      const values = [
+        { e1: 'Foo', e2: 'Qaz' },
+        { e1: 'Bar', e2: 'Qux' },
+      ]
+      const table = await createTableWithFields(
+        `e1 Enum('Foo', 'Bar'), e2 Enum('Qaz', 'Qux')`
+      )
+      await insertAndAssert(table, values)
+    })
+
+    it('should work with low cardinality', async () => {
+      const values = [
+        {
+          s: 'foo',
+          fs: 'bar',
+        },
+        {
+          s: 'qaz',
+          fs: 'qux',
+        },
+      ]
+      const table = await createTableWithFields(
+        's LowCardinality(String), fs LowCardinality(FixedString(3))'
+      )
+      await insertAndAssert(table, values)
+    })
+
+    it('should work with tuples', async () => {
+      const values = [
+        { t1: ['foo', 42], t2: ['2022-01-04', [1, 2]] },
+        { t1: ['bar', 43], t2: ['2015-04-15', [3, 4]] },
+      ]
+      const table = await createTableWithFields(
+        't1 Tuple(String, Int32), t2 Tuple(Date, Array(Int32))'
+      )
+      await insertAndAssert(table, values)
+    })
+
+    it('should work with nullable types', async () => {
+      const values = [
+        { s: 'foo', i: null, a: [null, null] },
+        { s: null, i: 42, a: [51, null] },
+      ]
+      const table = await createTableWithFields(
+        's Nullable(String), i Nullable(Int32), a Array(Nullable(Int32))'
+      )
+      await insertAndAssert(table, values)
+    })
+
+    it('should work with IP', async () => {
+      const values = [
+        {
+          ip1: '68.172.195.211',
+          ip2: 'f984:5f0b:bf33:e2db:16cd:567c:c1b3:20c4',
+        },
+        {
+          ip1: '184.232.227.132',
+          ip2: '2150:c3d5:f9e0:cdee:a94f:4580:d939:3901',
+        },
+      ]
+      const table = await createTableWithFields('ip1 IPv4, ip2 IPv6')
+      await insertAndAssert(table, values)
+    })
+
+    it('should work with ((very) nested) arrays', async () => {
+      // it's the largest reasonable nesting value (data is generated within 50 ms);
+      // 25 here can already tank the performance to ~500ms only to generate the data;
+      // 50 simply times out :)
+      const maxNestingLevel = 20
+
+      function genNestedArray(level: number): unknown {
+        if (level === 1) {
+          return [...Array(randomInt(2, 4))].map(() =>
+            Math.random().toString(36).slice(2)
+          )
+        }
+        return [...Array(randomInt(1, 3))].map(() => genNestedArray(level - 1))
+      }
+
+      function genArrayType(level: number): string {
+        if (level === 0) {
+          return 'String'
+        }
+        return `Array(${genArrayType(level - 1)})`
+      }
+
+      const values = [
+        {
+          a1: [42, 43],
+          a2: [
+            [
+              ['qaz', 144],
+              ['qux', 1024],
+            ],
+            [
+              ['qwerty', 102],
+              ['dvorak', -500],
+            ],
+          ],
+          a3: genNestedArray(maxNestingLevel),
+        },
+        {
+          a1: [44, 56],
+          a2: [
+            [
+              ['rtx', 60],
+              ['RDNA', 100],
+            ],
+            [
+              ['zen', 42],
+              ['core', 400],
+            ],
+          ],
+          a3: genNestedArray(maxNestingLevel),
+        },
+      ]
+      const table = await createTableWithFields(
+        'a1 Array(Int32), a2 Array(Array(Tuple(String, Int32))), ' +
+          `a3 ${genArrayType(maxNestingLevel)}`
+      )
+      await insertAndAssert(table, values)
+    })
+  })
+
+  it('should work with ((very) nested) maps', async () => {
+    const maxNestingLevel = 10
+
+    function genNestedMap(level: number): unknown {
+      const obj: Record<number, unknown> = {}
+      if (level === 1) {
+        ;[...Array(randomInt(2, 4))].forEach(
+          () => (obj[randomInt(1, 1000)] = Math.random().toString(36).slice(2))
+        )
+        return obj
+      }
+      ;[...Array(randomInt(1, 3))].forEach(
+        () => (obj[randomInt(1, 1000)] = genNestedMap(level - 1))
+      )
+      return obj
+    }
+
+    function genMapType(level: number): string {
+      if (level === 0) {
+        return 'String'
+      }
+      return `Map(Int32, ${genMapType(level - 1)})`
+    }
+
+    const values = [
+      {
+        m1: { foo: 'bar', qwe: 'rty' },
+        m2: { 1: '2', 3: '4' },
+        m3: genNestedMap(maxNestingLevel),
+      },
+      {
+        m1: { qaz: 'qux', sub: 'q' },
+        m2: { 3: '4', 4: '5' },
+        m3: {},
+      },
+    ]
+    const table = await createTableWithFields(
+      'm1 Map(String, String), m2 Map(Int32, Int64), ' +
+        `m3 ${genMapType(maxNestingLevel)}`
+    )
+    await insertAndAssert(table, values)
+  })
+
+  it('should work with (simple) aggregation functions', async () => {
+    const values = [
+      { route: 53, distance: 20.96 },
+      { route: 54, distance: 100.52 },
+      { route: 55, distance: 4.05 },
+    ]
+    const table = await createTableWithFields(
+      `route Int32, distance Decimal(10, 2)`
+    )
+    await client.insert({
+      table,
+      values,
+      format: 'JSONEachRow',
+    })
+    expect(
+      await client
+        .select({
+          query: `SELECT sum(distance) FROM ${table}`,
+          format: 'TabSeparated',
+        })
+        .then((r) => r.text())
+    ).toEqual('125.53\n')
+    expect(
+      await client
+        .select({
+          query: `SELECT max(distance) FROM ${table}`,
+          format: 'TabSeparated',
+        })
+        .then((r) => r.text())
+    ).toEqual('100.52\n')
+    expect(
+      await client
+        .select({
+          query: `SELECT uniqExact(distance) FROM ${table}`,
+          format: 'TabSeparated',
+        })
+        .then((r) => r.text())
+    ).toEqual('3\n')
+  })
+
+  // FIXME empty arrays in the result
+  //    Object {
+  //  -     "n.createdAt": "2001-04-23",
+  //  -     "n.id": 42,
+  //  -     "n.name": "foo",
+  //  -     "n.roles": Array [
+  //  -       "User",
+  //  -     ],
+  //  +     "n.createdAt": Array [],
+  //  +     "n.id": Array [],
+  //  +     "n.name": Array [],
+  //  +     "n.roles": Array [],
+  //    },
+  it.skip('should work with nested', async () => {
+    const values = [
+      {
+        id: 1,
+        n: {
+          id: 42,
+          name: 'foo',
+          createdAt: '2001-04-23',
+          roles: ['User'],
+        },
+      },
+      {
+        id: 2,
+        n: {
+          id: 43,
+          name: 'bar',
+          createdAt: '2000-01-12',
+          roles: ['Admin'],
+        },
+      },
+    ]
+    const table = await createTableWithFields(
+      'n Nested(id UInt32, name String, createdAt DateTime, ' +
+        `roles Array(Enum('User', 'Admin')))`
+    )
+    await client.insert({
+      table,
+      values,
+      format: 'JSONEachRow',
+    })
+    const result = await client
+      .select({
+        query: `SELECT n.id, n.name, n.createdAt, n.roles FROM ${table} ORDER BY id ASC`,
+        format: 'JSONEachRow',
+      })
+      .then((r) => r.json())
+    expect(result).toEqual([
+      {
+        'n.id': 42,
+        'n.name': 'foo',
+        'n.createdAt': '2001-04-23',
+        'n.roles': ['User'],
+      },
+      {
+        'n.id': 43,
+        'n.name': 'bar',
+        'n.createdAt': '2000-01-12',
+        'n.roles': ['Admin'],
+      },
+    ])
+  })
+
+  // TODO should belong to fixtures as it is quite useful in other tests
+  async function createTableWithFields(fields: string): Promise<string> {
+    const tableName = `data_types_test__${guid()}`
+    await createTable(client, (env) => {
+      switch (env) {
+        // ENGINE can be omitted in the cloud statements:
+        // it will use ReplicatedMergeTree and will add ON CLUSTER as well
+        case TestEnv.Cloud:
+          return `
+            CREATE TABLE ${tableName}
+            (id UInt32, ${fields})
+            ORDER BY (id)
+          `
+        case TestEnv.LocalSingleNode:
+          return `
+            CREATE TABLE ${tableName}
+            (id UInt32, ${fields})
+            ENGINE MergeTree()
+            ORDER BY (id)
+          `
+        case TestEnv.LocalCluster:
+          return `
+            CREATE TABLE ${tableName} ON CLUSTER '{cluster}'
+            (id UInt32, ${fields})
+            ENGINE ReplicatedMergeTree(
+              '/clickhouse/{cluster}/tables/{database}/{table}/{shard}', 
+              '{replica}'
+            )
+            ORDER BY (id)
+          `
+      }
+    })
+    return tableName
+  }
+
+  async function insertAndAssert<T>(table: string, data: T[]) {
+    const values = data.map((v, i) => ({ ...v, id: i + 1 }))
+    await client.insert({
+      table,
+      values,
+      format: 'JSONEachRow',
+    })
+    const result = await client
+      .select({
+        query: `SELECT * EXCEPT (id) FROM ${table} ORDER BY id ASC`,
+        format: 'JSONEachRow',
+      })
+      .then((r) => r.json())
+    expect(result).toEqual(data)
+  }
+})

--- a/__tests__/integration/schema_types.test.ts
+++ b/__tests__/integration/schema_types.test.ts
@@ -383,12 +383,6 @@ async function assertInsertAndSelect<S extends ch.Shape>(
   await table.insert({
     values: value,
   })
-  const result = await (
-    await table.select({
-      clickhouse_settings: {
-        s3_create_new_file_on_insert: 1,
-      },
-    })
-  ).json()
+  const result = await (await table.select()).json()
   expect(result).toEqual(value)
 }


### PR DESCRIPTION
#55 

Insert & Select
--
- [x] A dataset of several rows with all the language primitives
- [x] A test suit for each supported ClickHouse Data Type (Enum, Map, UInt 256, etc.)

`Nested` is skipped for the time being. 
`Decimal` does not work with the `JSON*` input format, not sure if it is intended or not.