### PR TITLE
Run Cloud tests with Node.js 18.x

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -125,7 +125,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        node: [14, 16]
+        node: [14, 16, 18]
 
     steps:
       - uses: actions/checkout@main


### PR DESCRIPTION
That one was missing for some reason.