### PR TITLE
add "ping" example and typings for method params

### DIFF
--- a/examples/ping_cloud.ts
+++ b/examples/ping_cloud.ts
@@ -1,0 +1,16 @@
+import { createClient } from '@clickhouse/client'
+void (async () => {
+  const client = createClient({
+    host: getFromEnv('CLICKHOUSE_HOST'),
+    password: getFromEnv('CLICKHOUSE_PASSWORD'),
+  })
+  console.info(await client.ping())
+})()
+
+function getFromEnv(key: string) {
+  if (process.env[key]) {
+    return process.env[key]
+  }
+  console.error(`${key} environment variable should be set`)
+  process.exit(1)
+}

--- a/src/client.ts
+++ b/src/client.ts
@@ -49,7 +49,7 @@ export interface BaseParams {
   clickhouse_settings?: ClickHouseSettings
   /** Parameters for query binding. https://clickhouse.com/docs/en/interfaces/http/#cli-queries-with-parameters */
   query_params?: Record<string, unknown>
-  /** AbortSignal instance to cancel a request in progress. */
+  /** AbortSignal instance (using `node-abort-controller` package) to cancel a request in progress. */
   abort_signal?: AbortSignal
 }
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -11,47 +11,66 @@ import { Rows } from './rows'
 import type { ClickHouseSettings } from './settings'
 
 export interface ClickHouseClientConfigOptions {
+  /** A ClickHouse instance URL. Default value: `http://localhost:8123`. */
   host?: string
+  /** The timeout to setup a connection in milliseconds. Default value: `10_000`. */
   connect_timeout?: number
+  /** The request timeout in milliseconds. Default value: `30_000`. */
   request_timeout?: number
+  /** Maximum number of sockets to allow per host. Default value: `Infinity`. */
   max_open_connections?: number
 
   compression?: {
+    /** `response: true` instructs ClickHouse server to respond with compressed response body. Default: true. */
     response?: boolean
+    /** `request: true` enabled compression on the client request body. Default: false. */
     request?: boolean
   }
-  // tls?: TlsOptions;
-
+  /** The name of the user on whose behalf requests are made. Default: 'default'. */
   username?: string
+  /** The user password. Default: ''. */
   password?: string
-
+  /** The name of the application using the nodejs client. Default: 'clickhouse-js'. */
   application?: string
+  /** Database name to use. Default value: `default`. */
   database?: string
+  /** ClickHouse settings to apply to all requests. Default value: {}  */
   clickhouse_settings?: ClickHouseSettings
   log?: {
+    /** Enable logging. Default value: false.  */
     enable?: boolean
+    /** A class to instantiate a custom logger implementation. */
     LoggerClass?: new (enabled: boolean) => Logger
   }
 }
 
 export interface BaseParams {
+  /** ClickHouse settings that can be applied on query level. */
   clickhouse_settings?: ClickHouseSettings
+  /** Parameters for query binding. https://clickhouse.com/docs/en/interfaces/http/#cli-queries-with-parameters */
   query_params?: Record<string, unknown>
+  /** AbortSignal instance to cancel a request in progress. */
   abort_signal?: AbortSignal
 }
 
 export interface QueryParams extends BaseParams {
+  /** Statement to execute. */
   query: string
+  /** Format of the resulting dataset. */
   format?: DataFormat
 }
 
 export interface ExecParams extends BaseParams {
+  /** Statement to execute. */
   query: string
 }
 
 export interface InsertParams<T = unknown> extends BaseParams {
+  /** Name of a table to insert into. */
   table: string
+  /** A dataset to insert. */
   values: ReadonlyArray<T> | Stream.Readable
+  /** Format of the dataset to insert. */
   format?: DataFormat
 }
 


### PR DESCRIPTION
While working on documentation, I noticed a few gaps in examples and typings. More might follow in the following PRs.