### PR TITLE
Rework `enable_http_compression` behaviour in the client

### DIFF
--- a/.docker/clickhouse/users.xml
+++ b/.docker/clickhouse/users.xml
@@ -4,6 +4,7 @@
     <profiles>
         <default>
             <load_balancing>random</load_balancing>
+            <enable_http_compression>1</enable_http_compression>
         </default>
     </profiles>
 

--- a/README.md
+++ b/README.md
@@ -109,7 +109,8 @@ export interface ClickHouseClientConfigOptions {
   // HTTP compression settings. Uses GZIP.
   // For more details, see https://clickhouse.com/docs/en/interfaces/http/#compression
   compression?: {
-    // enabled by default - the server will compress the data it sends to you in the response
+    // enabled by default on the client
+    // instructs ClickHouse server to respond with compressed response body
     response?: boolean
     // disabled by default - the server will decompress the data which you pass in the request
     request?: boolean
@@ -366,6 +367,27 @@ class ClickHouseClient {
   // ...
 }
 ```
+
+## Compression
+
+When `ClickHouseClientConfigOptions.compression.response` is set to `true`,
+the client essentially just sets the `Accept-Encoding: gzip` header.
+The compression will be actually enabled when on of the following conditions is met:
+
+- User's profile has `<enable_http_compression>1</enable_http_compression>` entry;
+- Additional ClickHouse setting is supplied on the query level, i.e.
+
+```ts
+client.query({
+  query: 'SELECT * FROM ...',
+  format: 'JSONEachRow',
+  clickhouse_settings: {
+    enable_http_compression: 1,
+  },
+})
+```
+
+NB: `enable_http_compression: 1` can be set per query only if current user is _not read-only_.
 
 ## Usage examples
 

--- a/__tests__/unit/http_adapter.test.ts
+++ b/__tests__/unit/http_adapter.test.ts
@@ -60,29 +60,6 @@ describe('HttpAdapter', () => {
         assertStub(undefined)
       })
 
-      it('uses request-specific settings over config settings', async () => {
-        const adapter = buildHttpAdapter({
-          compression: {
-            decompress_response: false,
-            compress_request: false,
-          },
-        })
-        const request = stubRequest()
-
-        const selectPromise = adapter.query({
-          query: 'SELECT * FROM system.numbers LIMIT 5',
-          clickhouse_settings: {
-            enable_http_compression: 1,
-          },
-        })
-
-        const responseBody = 'foobar'
-        await emitCompressedBody(request, responseBody)
-
-        expect(await getAsText(await selectPromise)).toBe(responseBody)
-        assertStub('gzip')
-      })
-
       it('decompresses a gzip response', async () => {
         const adapter = buildHttpAdapter({
           compression: {

--- a/src/client.ts
+++ b/src/client.ts
@@ -13,7 +13,7 @@ import type { ClickHouseSettings } from './settings'
 export interface ClickHouseClientConfigOptions {
   /** A ClickHouse instance URL. Default value: `http://localhost:8123`. */
   host?: string
-  /** The timeout to setup a connection in milliseconds. Default value: `10_000`. */
+  /** The timeout to set up a connection in milliseconds. Default value: `10_000`. */
   connect_timeout?: number
   /** The request timeout in milliseconds. Default value: `30_000`. */
   request_timeout?: number
@@ -21,9 +21,17 @@ export interface ClickHouseClientConfigOptions {
   max_open_connections?: number
 
   compression?: {
-    /** `response: true` instructs ClickHouse server to respond with compressed response body. Default: true. */
+    /**
+     * `response: true` instructs ClickHouse server
+     * to respond with compressed response body.
+     * Default: true.
+     */
     response?: boolean
-    /** `request: true` enabled compression on the client request body. Default: false. */
+    /**
+     * `request: true` enables compression on the client request body
+     * and instructs ClickHouse server to decode it.
+     * Default: false.
+     */
     request?: boolean
   }
   /** The name of the user on whose behalf requests are made. Default: 'default'. */


### PR DESCRIPTION
* Do not enforce `enable_http_compression=1` setting if `compression.response` set to `true` - it is now required to have it either in the server's `users.xml` or supply it separately
* Update the README