### PR TITLE
Allow semicolons in select clauses

### DIFF
--- a/__tests__/integration/exec.test.ts
+++ b/__tests__/integration/exec.test.ts
@@ -74,11 +74,11 @@ describe('exec', () => {
   })
 
   describe('trailing semi', () => {
-    it('should cut off the statements after the first semi', async () => {
+    it('should allow commands with semi in select clause', async () => {
       const result = await client.exec({
-        query: 'EXISTS system.databases;asdf foobar',
+        query: `SELECT ';' FORMAT CSV`,
       })
-      expect(await getAsText(result)).toEqual('1\n')
+      expect(await getAsText(result)).toEqual('";"\n')
     })
 
     it('should allow commands with trailing semi', async () => {

--- a/__tests__/integration/select.test.ts
+++ b/__tests__/integration/select.test.ts
@@ -503,12 +503,12 @@ describe('select', () => {
       expect(await numbers.text()).toEqual('0\n1\n2\n')
     })
 
-    it('should cut off the statements after the first semi', async () => {
-      const numbers = await client.query({
-        query: 'SELECT * FROM system.numbers LIMIT 3;asdf foobar',
+    it('should allow semi in select clause', async () => {
+      const resultSet = await client.query({
+        query: `SELECT ';'`,
         format: 'CSV',
       })
-      expect(await numbers.text()).toEqual('0\n1\n2\n')
+      expect(await resultSet.text()).toEqual('";"\n')
     })
   })
 })

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clickhouse/client",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "Official JS client for ClickHouse DB",
   "license": "Apache-2.0",
   "keywords": [

--- a/src/client.ts
+++ b/src/client.ts
@@ -164,7 +164,7 @@ export class ClickHouseClient {
   }
 
   exec(params: ExecParams): Promise<Stream.Readable> {
-    const query = removeSemi(params.query.trim())
+    const query = removeTrailingSemi(params.query.trim())
     return this.connection.exec({
       query,
       ...this.getBaseParams(params),
@@ -195,14 +195,20 @@ export class ClickHouseClient {
 
 function formatQuery(query: string, format: DataFormat): string {
   query = query.trim()
-  query = removeSemi(query)
+  query = removeTrailingSemi(query)
   return query + ' \nFORMAT ' + format
 }
 
-function removeSemi(query: string) {
-  const idx = query.indexOf(';')
-  if (idx !== -1) {
-    return query.slice(0, idx)
+function removeTrailingSemi(query: string) {
+  let lastNonSemiIdx = query.length
+  for (let i = lastNonSemiIdx; i > 0; i--) {
+    if (query[i - 1] !== ';') {
+      lastNonSemiIdx = i
+      break
+    }
+  }
+  if (lastNonSemiIdx !== query.length) {
+    return query.slice(0, lastNonSemiIdx)
   }
   return query
 }


### PR DESCRIPTION
A quick fix that resolves #116 
Instead of cutting off everything after the first encountered semi, scan the query string backwards and stop after the first non-semi character.
