### PR TITLE
remove request listeners synchronously

### DIFF
--- a/src/connection/adapter/base_http_adapter.ts
+++ b/src/connection/adapter/base_http_adapter.ts
@@ -153,7 +153,7 @@ export abstract class BaseHttpAdapter implements Connection {
 
       function onAbort(): void {
         // Prefer 'abort' event since it always triggered unlike 'error' and 'close'
-        // * see the full sequence of events https://nodejs.org/api/http.html#httprequesturl-options-callback
+        // see the full sequence of events https://nodejs.org/api/http.html#httprequesturl-options-callback
         removeRequestListeners()
         request.once('error', function () {
           /**
@@ -167,9 +167,8 @@ export abstract class BaseHttpAdapter implements Connection {
       function onClose(): void {
         // Adapter uses 'close' event to clean up listeners after the successful response.
         // It's necessary in order to handle 'abort' and 'timeout' events while response is streamed.
-        // setImmediate is a workaround. If a request cancelled before sent, the 'abort' happens after 'close'.
-        // Which contradicts the docs https://nodejs.org/docs/latest-v14.x/api/http.html#http_http_request_url_options_callback
-        setImmediate(removeRequestListeners)
+        // It's always the last event, according to https://nodejs.org/docs/latest-v14.x/api/http.html#http_http_request_url_options_callback
+        removeRequestListeners()
       }
 
       function removeRequestListeners(): void {


### PR DESCRIPTION
closes https://github.com/ClickHouse/clickhouse-js/issues/123

The PR removes listeners synchronously to avoid a race condition reported in https://github.com/ClickHouse/clickhouse-js/issues/123.
While running https://github.com/ClickHouse/clickhouse-js/blob/main/__tests__/integration/abort_request.test.ts and other test suits, I didn't manage to reproduce the problem described in the old comment, so I removed `setImmediate` workaround. 