### PR TITLE
Add Changelog.md

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,7 @@ on:
     branches:
       - main
     paths-ignore:
-      - 'README.md'
+      - '**/*.md'
       - 'LICENSE'
       - 'benchmarks/**'
       - 'examples/**'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,25 +1,25 @@
-## 0.0.10 2022-11-14
+## 0.0.10, 2022-11-14
 ### New features
 - Remove request listeners synchronously. [#123](https://github.com/ClickHouse/clickhouse-js/issues/123)
 
-## 0.0.9 2022-10-25
+## 0.0.9, 2022-10-25
 ### New features
 - Added ClickHouse session_id support. [#121](https://github.com/ClickHouse/clickhouse-js/pull/121)
 
-## 0.0.8 2022-10-18
+## 0.0.8, 2022-10-18
 ### New features
 - Added SSL/TLS support (basic and mutual). [#52](https://github.com/ClickHouse/clickhouse-js/issues/52)
 
 
-## 0.0.7 2022-10-18
+## 0.0.7, 2022-10-18
 ### Bug fixes
 - Allow semicolons in select clause. [#116](https://github.com/ClickHouse/clickhouse-js/issues/116)
 
-## 0.0.6 2022-10-07
+## 0.0.6, 2022-10-07
 ### New features
 - Add JSONObjectEachRow input/output and JSON input formats. [#113](https://github.com/ClickHouse/clickhouse-js/pull/113)
 
-## 0.0.5 2022-10-04
+## 0.0.5, 2022-10-04
 ### Breaking changes
   - Rows abstraction was renamed to ResultSet.
   - now, every iteration over ResultSet.stream() yields Row[] instead of a single Row. Please check out an example and this PR for more details. These changes allowed us to significantly reduce overhead on select result set streaming.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,27 @@
+## 0.0.10 2022-11-14
+### New features
+- Remove request listeners synchronously. [#123](https://github.com/ClickHouse/clickhouse-js/issues/123)
+
+## 0.0.9 2022-10-25
+### New features
+- Added ClickHouse session_id support. [#121](https://github.com/ClickHouse/clickhouse-js/pull/121)
+
+## 0.0.8 2022-10-18
+### New features
+- Added SSL/TLS support (basic and mutual). [#52](https://github.com/ClickHouse/clickhouse-js/issues/52)
+
+
+## 0.0.7 2022-10-18
+### Bug fixes
+- Allow semicolons in select clause. [#116](https://github.com/ClickHouse/clickhouse-js/issues/116)
+
+## 0.0.6 2022-10-07
+### New features
+- Add JSONObjectEachRow input/output and JSON input formats. [#113](https://github.com/ClickHouse/clickhouse-js/pull/113)
+
+## 0.0.5 2022-10-04
+### Breaking changes
+  - Rows abstraction was renamed to ResultSet.
+  - now, every iteration over ResultSet.stream() yields Row[] instead of a single Row. Please check out an example and this PR for more details. These changes allowed us to significantly reduce overhead on select result set streaming.
+### New features
+- split2 is no longer a package dependency.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,27 +1,34 @@
 ## 0.0.10, 2022-11-14
 ### New features
-- Remove request listeners synchronously. [#123](https://github.com/ClickHouse/clickhouse-js/issues/123)
+- Remove request listeners synchronously.
+[#123](https://github.com/ClickHouse/clickhouse-js/issues/123)
 
 ## 0.0.9, 2022-10-25
 ### New features
-- Added ClickHouse session_id support. [#121](https://github.com/ClickHouse/clickhouse-js/pull/121)
+- Added ClickHouse session_id support.
+[#121](https://github.com/ClickHouse/clickhouse-js/pull/121)
 
 ## 0.0.8, 2022-10-18
 ### New features
-- Added SSL/TLS support (basic and mutual). [#52](https://github.com/ClickHouse/clickhouse-js/issues/52)
-
+- Added SSL/TLS support (basic and mutual).
+[#52](https://github.com/ClickHouse/clickhouse-js/issues/52)
 
 ## 0.0.7, 2022-10-18
 ### Bug fixes
-- Allow semicolons in select clause. [#116](https://github.com/ClickHouse/clickhouse-js/issues/116)
+- Allow semicolons in select clause.
+[#116](https://github.com/ClickHouse/clickhouse-js/issues/116)
 
 ## 0.0.6, 2022-10-07
 ### New features
-- Add JSONObjectEachRow input/output and JSON input formats. [#113](https://github.com/ClickHouse/clickhouse-js/pull/113)
+- Add JSONObjectEachRow input/output and JSON input formats.
+[#113](https://github.com/ClickHouse/clickhouse-js/pull/113)
 
 ## 0.0.5, 2022-10-04
 ### Breaking changes
   - Rows abstraction was renamed to ResultSet.
-  - now, every iteration over ResultSet.stream() yields Row[] instead of a single Row. Please check out an example and this PR for more details. These changes allowed us to significantly reduce overhead on select result set streaming.
+  - now, every iteration over `ResultSet.stream()` yields `Row[]` instead of a single `Row`.
+Please check out [an example](https://github.com/ClickHouse/clickhouse-js/blob/c86c31dada8f4845cd4e6843645177c99bc53a9d/examples/select_streaming_on_data.ts)
+and [this PR](https://github.com/ClickHouse/clickhouse-js/pull/109) for more details.
+These changes allowed us to significantly reduce overhead on select result set streaming.
 ### New features
-- split2 is no longer a package dependency.
+- [split2](https://www.npmjs.com/package/split2) is no longer a package dependency.


### PR DESCRIPTION
Adds standard CHANGELOG.md to report notable changes between versions. A separate file is easy to port for the different representations (on the website, application UI, etc.).
Starting from the next release, we can reference CHANGELOG.md from `Release notes` to have a single source of truth. 