### PR TITLE
Add Node.js 19.x to the CI pipeline

### DIFF
--- a/.docker/clickhouse/single_node_tls/Dockerfile
+++ b/.docker/clickhouse/single_node_tls/Dockerfile
@@ -1,4 +1,4 @@
-FROM clickhouse/clickhouse-server:22.11.2-alpine
+FROM clickhouse/clickhouse-server:22.12-alpine
 COPY .docker/clickhouse/single_node_tls/certificates /etc/clickhouse-server/certs
 RUN chown clickhouse:clickhouse -R /etc/clickhouse-server/certs \
     && chmod 600 /etc/clickhouse-server/certs/* \

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,7 +37,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        node: [ 14, 16, 18 ]
+        node: [ 14, 16, 18, 19 ]
     steps:
       - uses: actions/checkout@main
 
@@ -68,7 +68,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        node: [ 14, 16, 18 ]
+        node: [ 14, 16, 18, 19 ]
         clickhouse: [ head, latest ]
 
     steps:
@@ -117,7 +117,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        node: [ 14, 16, 18 ]
+        node: [ 14, 16, 18, 19 ]
         clickhouse: [ head, latest ]
 
     steps:
@@ -150,7 +150,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        node: [ 14, 16, 18 ]
+        node: [ 14, 16, 18, 19 ]
 
     steps:
       - uses: actions/checkout@main

--- a/__tests__/integration/abort_request.test.ts
+++ b/__tests__/integration/abort_request.test.ts
@@ -96,8 +96,11 @@ describe('abort request', () => {
             })
           }
         })
-      // There was a breaking change in Node.js 18.x behavior
-      if (process.version.startsWith('v18')) {
+      // There was a breaking change in Node.js 18.x+ behavior
+      if (
+        process.version.startsWith('v18') ||
+        process.version.startsWith('v19')
+      ) {
         await expect(selectPromise).rejects.toMatchObject({
           message: 'Premature close',
         })

--- a/__tests__/integration/config.test.ts
+++ b/__tests__/integration/config.test.ts
@@ -140,13 +140,13 @@ describe('config', () => {
       client = createTestClient({
         max_open_connections: 1,
       })
-      void select('SELECT 1 AS x, sleep(0.2)')
-      void select('SELECT 2 AS x, sleep(0.2)')
+      void select('SELECT 1 AS x, sleep(0.3)')
+      void select('SELECT 2 AS x, sleep(0.3)')
       await retryOnFailure(async () => {
         expect(results).toEqual([1])
       }, retryOpts)
       await retryOnFailure(async () => {
-        expect(results).toEqual([1, 2])
+        expect(results.sort()).toEqual([1, 2])
       }, retryOpts)
     })
 
@@ -154,19 +154,19 @@ describe('config', () => {
       client = createTestClient({
         max_open_connections: 2,
       })
-      void select('SELECT 1 AS x, sleep(0.2)')
-      void select('SELECT 2 AS x, sleep(0.2)')
-      void select('SELECT 3 AS x, sleep(0.2)')
-      void select('SELECT 4 AS x, sleep(0.2)')
+      void select('SELECT 1 AS x, sleep(0.3)')
+      void select('SELECT 2 AS x, sleep(0.3)')
+      void select('SELECT 3 AS x, sleep(0.3)')
+      void select('SELECT 4 AS x, sleep(0.3)')
       await retryOnFailure(async () => {
         expect(results).toContain(1)
         expect(results).toContain(2)
-        expect(results.length).toEqual(2)
+        expect(results.sort()).toEqual([1, 2])
       }, retryOpts)
       await retryOnFailure(async () => {
         expect(results).toContain(3)
         expect(results).toContain(4)
-        expect(results.length).toEqual(4)
+        expect(results.sort()).toEqual([1, 2, 3, 4])
       }, retryOpts)
     })
   })

--- a/__tests__/tls/tls.test.ts
+++ b/__tests__/tls/tls.test.ts
@@ -76,11 +76,14 @@ describe('TLS connection', () => {
         key: fs.readFileSync(`${certsPath}/server.key`),
       },
     })
+    const errorMessage = process.version.startsWith('v19')
+      ? 'unsupported certificate'
+      : 'socket hang up'
     await expect(
       client.query({
         query: 'SELECT number FROM system.numbers LIMIT 3',
         format: 'CSV',
       })
-    ).rejects.toThrowError('socket hang up')
+    ).rejects.toThrowError(errorMessage)
   })
 })

--- a/docker-compose.cluster.yml
+++ b/docker-compose.cluster.yml
@@ -2,7 +2,7 @@ version: '2.3'
 
 services:
   clickhouse1:
-    image: 'clickhouse/clickhouse-server:${CLICKHOUSE_VERSION-22.11.2-alpine}'
+    image: 'clickhouse/clickhouse-server:${CLICKHOUSE_VERSION-22.12-alpine}'
     ulimits:
       nofile:
         soft: 262144
@@ -19,7 +19,7 @@ services:
       - './.docker/clickhouse/users.xml:/etc/clickhouse-server/users.xml'
 
   clickhouse2:
-    image: 'clickhouse/clickhouse-server:${CLICKHOUSE_VERSION-22.11.2-alpine}'
+    image: 'clickhouse/clickhouse-server:${CLICKHOUSE_VERSION-22.12-alpine}'
     ulimits:
       nofile:
         soft: 262144

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.8'
 services:
   clickhouse:
-    image: 'clickhouse/clickhouse-server:${CLICKHOUSE_VERSION-22.11.2-alpine}'
+    image: 'clickhouse/clickhouse-server:${CLICKHOUSE_VERSION-22.12-alpine}'
     container_name: 'clickhouse-js-clickhouse-server'
     ports:
       - '8123:8123'


### PR DESCRIPTION
* Update tests to support Node.js 19.x
* Bump CH server version
* Reduce tests flakiness