### PR TITLE
Set the User-Agent header according to the language client spec

### DIFF
--- a/.build/update_version.ts
+++ b/.build/update_version.ts
@@ -1,0 +1,21 @@
+import version from '../src/version'
+import packageJson from '../package.json'
+import fs from 'fs'
+
+;(async () => {
+  console.log(`Current package version is: ${version}`)
+  packageJson.version = version
+  console.log('Updated package json:')
+  console.log(packageJson)
+  try {
+    fs.writeFileSync(
+      './package.json',
+      JSON.stringify(packageJson, null, 2) + '\n',
+      'utf-8'
+    )
+  } catch (err) {
+    console.error(err)
+    process.exit(1)
+  }
+  process.exit(0)
+})()

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,8 @@ jobs:
         with:
           node-version: '16.x'
           registry-url: 'https://registry.npmjs.org'
+      - name: Update package version
+        run: ts-node --transpile-only --project tsconfig.dev.json .build/update_version.ts
       - run: npm i --ignore-scripts
       - run: npm run build
       - run: npm publish

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -169,3 +169,8 @@ npm t -- --coverage
 ```
 
 Please don't commit the coverage reports manually.
+
+## Update package version
+Don't forget to change the package version in `src/version.ts` before the release.
+
+`release` GitHub action will pick it up and replace `package.json` version automatically.

--- a/__tests__/integration/config.test.ts
+++ b/__tests__/integration/config.test.ts
@@ -68,7 +68,9 @@ describe('config', () => {
         1,
         expect.stringContaining('Got a response from ClickHouse'),
         expect.objectContaining({
-          request_headers: {},
+          request_headers: {
+            'user-agent': expect.any(String),
+          },
           request_method: 'GET',
           request_params: '',
           request_path: '/ping',

--- a/__tests__/unit/http_adapter.test.ts
+++ b/__tests__/unit/http_adapter.test.ts
@@ -8,6 +8,7 @@ import { HttpAdapter } from '../../src/connection/adapter'
 import { retryOnFailure, TestLogger } from '../utils'
 import { getAsText } from '../../src/utils'
 import { LogWriter } from '../../src/logger'
+import { BaseHttpAdapter } from '../../src/connection/adapter/base_http_adapter'
 
 describe('HttpAdapter', () => {
   const gzip = Util.promisify(Zlib.gzip)
@@ -237,6 +238,42 @@ describe('HttpAdapter', () => {
         })
       )
     }
+  })
+
+  describe('User-Agent', () => {
+    class MyTestHttpAdapter extends BaseHttpAdapter {
+      constructor(application_id?: string) {
+        super(
+          { application_id } as ConnectionParams,
+          new TestLogger(),
+          {} as Http.Agent
+        )
+      }
+      protected createClientRequest(): Http.ClientRequest {
+        return {} as any
+      }
+      public getDefaultHeaders() {
+        return this.headers
+      }
+    }
+
+    it('should have proper user agent without app id', async () => {
+      const myHttpAdapter = new MyTestHttpAdapter()
+      const headers = myHttpAdapter.getDefaultHeaders()
+      expect(headers['Authorization']).toMatch(/^Basic [A-Za-z0-9/+=]+$/)
+      expect(headers['User-Agent']).toMatch(
+        /^clickhouse-js\/[0-9\\.]+? \(lv:nodejs\/v[0-9\\.]+?; os:(?:linux|darwin|win32)\)$/
+      )
+    })
+
+    it('should have proper user agent with app id', async () => {
+      const myHttpAdapter = new MyTestHttpAdapter('MyFancyApp')
+      const headers = myHttpAdapter.getDefaultHeaders()
+      expect(headers['Authorization']).toMatch(/^Basic [A-Za-z0-9/+=]+$/)
+      expect(headers['User-Agent']).toMatch(
+        /^MyFancyApp clickhouse-js\/[0-9\\.]+? \(lv:nodejs\/v[0-9\\.]+?; os:(?:linux|darwin|win32)\)$/
+      )
+    })
   })
 
   function buildIncomingMessage({

--- a/__tests__/unit/http_adapter.test.ts
+++ b/__tests__/unit/http_adapter.test.ts
@@ -241,26 +241,9 @@ describe('HttpAdapter', () => {
   })
 
   describe('User-Agent', () => {
-    class MyTestHttpAdapter extends BaseHttpAdapter {
-      constructor(application_id?: string) {
-        super(
-          { application_id } as ConnectionParams,
-          new TestLogger(),
-          {} as Http.Agent
-        )
-      }
-      protected createClientRequest(): Http.ClientRequest {
-        return {} as any
-      }
-      public getDefaultHeaders() {
-        return this.headers
-      }
-    }
-
     it('should have proper user agent without app id', async () => {
       const myHttpAdapter = new MyTestHttpAdapter()
       const headers = myHttpAdapter.getDefaultHeaders()
-      expect(headers['Authorization']).toMatch(/^Basic [A-Za-z0-9/+=]+$/)
       expect(headers['User-Agent']).toMatch(
         /^clickhouse-js\/[0-9\\.]+? \(lv:nodejs\/v[0-9\\.]+?; os:(?:linux|darwin|win32)\)$/
       )
@@ -269,11 +252,16 @@ describe('HttpAdapter', () => {
     it('should have proper user agent with app id', async () => {
       const myHttpAdapter = new MyTestHttpAdapter('MyFancyApp')
       const headers = myHttpAdapter.getDefaultHeaders()
-      expect(headers['Authorization']).toMatch(/^Basic [A-Za-z0-9/+=]+$/)
       expect(headers['User-Agent']).toMatch(
         /^MyFancyApp clickhouse-js\/[0-9\\.]+? \(lv:nodejs\/v[0-9\\.]+?; os:(?:linux|darwin|win32)\)$/
       )
     })
+  })
+
+  it('should have proper auth header', async () => {
+    const myHttpAdapter = new MyTestHttpAdapter()
+    const headers = myHttpAdapter.getDefaultHeaders()
+    expect(headers['Authorization']).toMatch(/^Basic [A-Za-z0-9/+=]+$/)
   })
 
   function buildIncomingMessage({
@@ -321,3 +309,19 @@ describe('HttpAdapter', () => {
     )
   }
 })
+
+class MyTestHttpAdapter extends BaseHttpAdapter {
+  constructor(application_id?: string) {
+    super(
+      { application_id } as ConnectionParams,
+      new TestLogger(),
+      {} as Http.Agent
+    )
+  }
+  protected createClientRequest(): Http.ClientRequest {
+    return {} as any
+  }
+  public getDefaultHeaders() {
+    return this.headers
+  }
+}

--- a/__tests__/unit/user_agent.test.ts
+++ b/__tests__/unit/user_agent.test.ts
@@ -1,0 +1,37 @@
+import * as p from '../../src/utils/process'
+import { getProcessVersion } from '../../src/utils/process'
+import * as os from 'os'
+import { getUserAgent } from '../../src/utils/user_agent'
+
+jest.mock('os')
+jest.mock('../../src/version', () => {
+  return '0.0.42'
+})
+describe('user_agent', () => {
+  describe('process util', () => {
+    it('should get correct process version by default', async () => {
+      expect(getProcessVersion()).toEqual(process.version)
+    })
+  })
+
+  it('should generate a user agent without app id', async () => {
+    setupMocks()
+    const userAgent = getUserAgent()
+    expect(userAgent).toEqual(
+      'clickhouse-js/0.0.42 (lv:nodejs/v16.144; os:freebsd)'
+    )
+  })
+
+  it('should generate a user agent with app id', async () => {
+    setupMocks()
+    const userAgent = getUserAgent()
+    expect(userAgent).toEqual(
+      'clickhouse-js/0.0.42 (lv:nodejs/v16.144; os:freebsd)'
+    )
+  })
+
+  function setupMocks() {
+    jest.spyOn(os, 'platform').mockReturnValueOnce('freebsd')
+    jest.spyOn(p, 'getProcessVersion').mockReturnValueOnce('v16.144')
+  }
+})

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clickhouse/client",
-  "version": "0.0.11",
+  "version": "0.0.0",
   "description": "Official JS client for ClickHouse DB",
   "license": "Apache-2.0",
   "keywords": [

--- a/src/client.ts
+++ b/src/client.ts
@@ -33,7 +33,7 @@ export interface ClickHouseClientConfigOptions {
   username?: string
   /** The user password. Default: ''. */
   password?: string
-  /** The name of the application using the nodejs client. Default: 'clickhouse-js'. */
+  /** The name of the application using the nodejs client. Default: empty. */
   application?: string
   /** Database name to use. Default value: `default`. */
   database?: string
@@ -126,6 +126,7 @@ function normalizeConfig(config: ClickHouseClientConfigOptions) {
     }
   }
   return {
+    application_id: config.application,
     url: createUrl(config.host ?? 'http://localhost:8123'),
     connect_timeout: config.connect_timeout ?? 10_000,
     request_timeout: config.request_timeout ?? 300_000,

--- a/src/connection/adapter/base_http_adapter.ts
+++ b/src/connection/adapter/base_http_adapter.ts
@@ -15,6 +15,7 @@ import { toSearchParams } from './http_search_params'
 import { transformUrl } from './transform_url'
 import { getAsText, isStream } from '../../utils'
 import type { ClickHouseSettings } from '../../settings'
+import { getUserAgent } from '../../utils/user_agent'
 
 export interface RequestParams {
   method: 'GET' | 'POST'
@@ -97,6 +98,7 @@ export abstract class BaseHttpAdapter implements Connection {
       Authorization: `Basic ${Buffer.from(`${username}:${password}`).toString(
         'base64'
       )}`,
+      'User-Agent': getUserAgent(this.config.application_id),
     }
   }
 

--- a/src/connection/connection.ts
+++ b/src/connection/connection.ts
@@ -6,6 +6,8 @@ import type { ClickHouseSettings } from '../settings'
 export interface ConnectionParams {
   url: URL
 
+  application_id?: string
+
   connect_timeout: number
   request_timeout: number
   max_open_connections: number

--- a/src/utils/process.ts
+++ b/src/utils/process.ts
@@ -1,0 +1,4 @@
+// for easy mocking in the tests
+export function getProcessVersion(): string {
+  return process.version
+}

--- a/src/utils/user_agent.ts
+++ b/src/utils/user_agent.ts
@@ -1,0 +1,16 @@
+import * as os from 'os'
+import packageVersion from '../version'
+import { getProcessVersion } from './process'
+
+/**
+ * Generate a user agent string like
+ * clickhouse-js/0.0.11 (lv:nodejs/19.0.4; os:linux)
+ * or
+ * MyApplicationName clickhouse-js/0.0.11 (lv:nodejs/19.0.4; os:linux)
+ */
+export function getUserAgent(application_id?: string): string {
+  const defaultUserAgent = `clickhouse-js/${packageVersion} (lv:nodejs/${getProcessVersion()}; os:${os.platform()})`
+  return application_id
+    ? `${application_id} ${defaultUserAgent}`
+    : defaultUserAgent
+}

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,0 +1,1 @@
+export default '0.0.11'

--- a/tsconfig.dev.json
+++ b/tsconfig.dev.json
@@ -4,7 +4,8 @@
     "./src/**/*.ts",
     "__tests__/**/*.ts",
     "examples/**/*.ts",
-    "benchmarks/**/*.ts"
+    "benchmarks/**/*.ts",
+    ".build/**/*.ts"
   ],
   "compilerOptions": {
     "noUnusedLocals": false,


### PR DESCRIPTION
## Summary
Set the User-Agent header according to the [language client spec](https://docs.google.com/document/d/1924Dvy79KXIhfqKpi1EBVY3133pIdoMwgCQtZ-uhEKs/edit#heading=h.ah33hoz5xei2)

## Checklist
Delete items not relevant to your PR:
- [x] Unit and integration tests covering the common scenarios were added
- [ ] Update the changelog when #132 is merged to avoid the conflicts


