### PR TITLE
Fix read-only user tests

### DIFF
--- a/__tests__/integration/fixtures/read_only_user.ts
+++ b/__tests__/integration/fixtures/read_only_user.ts
@@ -8,7 +8,7 @@ import type { ClickHouseClient } from '../../../src'
 
 export async function createReadOnlyUser(client: ClickHouseClient) {
   const username = `clickhousejs__read_only_user_${guid()}`
-  const password = guid()
+  const password = `CHJS_${guid()};`
   const database = getTestDatabaseName()
   const env = getClickHouseTestEnvironment()
   let createUser: string


### PR DESCRIPTION
## Summary

As of today, read-only user tests started to fail with the Cloud because the password was too simple:

> Invalid password. The password should: contain at least 1 uppercase character, contain at least 1 special character.

## Checklist
- [x] Unit and integration tests covering the common scenarios were added
