### PR TITLE
Prepare 0.0.14, bump CH version to 23.2

### DIFF
--- a/.docker/clickhouse/single_node_tls/Dockerfile
+++ b/.docker/clickhouse/single_node_tls/Dockerfile
@@ -1,4 +1,4 @@
-FROM clickhouse/clickhouse-server:23.1-alpine
+FROM clickhouse/clickhouse-server:23.2-alpine
 COPY .docker/clickhouse/single_node_tls/certificates /etc/clickhouse-server/certs
 RUN chown clickhouse:clickhouse -R /etc/clickhouse-server/certs \
     && chmod 600 /etc/clickhouse-server/certs/* \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.0.14
+
+### New features
+* Added support for `JSONStrings`, `JSONCompact`, `JSONCompactStrings`, `JSONColumnsWithMetadata` formats (@andrewzolotukhin).
+
 ## 0.0.13
 
 ### New features

--- a/__tests__/unit/encode_values.test.ts
+++ b/__tests__/unit/encode_values.test.ts
@@ -3,7 +3,7 @@ import { encodeValues } from '../../src/client'
 import type { DataFormat, InputJSON, InputJSONObjectEachRow } from '../../src'
 
 describe('encodeValues', () => {
-  const rawStreamFormats = [
+  const rawFormats = [
     'CSV',
     'CSVWithNames',
     'CSVWithNamesAndTypes',
@@ -15,7 +15,7 @@ describe('encodeValues', () => {
     'CustomSeparatedWithNames',
     'CustomSeparatedWithNamesAndTypes',
   ]
-  const jsonStreamFormats = [
+  const jsonFormats = [
     'JSON',
     'JSONStrings',
     'JSONCompact',
@@ -35,14 +35,14 @@ describe('encodeValues', () => {
     const values = Stream.Readable.from('foo,bar\n', {
       objectMode: false,
     })
-    rawStreamFormats.forEach((format) => {
+    rawFormats.forEach((format) => {
       // should be exactly the same object (no duplicate instances)
       expect(encodeValues(values, format as DataFormat)).toEqual(values)
     })
   })
 
   it('should encode JSON streams per line', async () => {
-    for (const format of jsonStreamFormats) {
+    for (const format of jsonFormats) {
       const values = Stream.Readable.from(['foo', 'bar'], {
         objectMode: true,
       })
@@ -56,7 +56,7 @@ describe('encodeValues', () => {
   })
 
   it('should encode JSON arrays', async () => {
-    for (const format of jsonStreamFormats) {
+    for (const format of jsonFormats) {
       const values = ['foo', 'bar']
       const result = encodeValues(values, format as DataFormat)
       let encoded = ''

--- a/docker-compose.cluster.yml
+++ b/docker-compose.cluster.yml
@@ -2,7 +2,7 @@ version: '2.3'
 
 services:
   clickhouse1:
-    image: 'clickhouse/clickhouse-server:${CLICKHOUSE_VERSION-23.1-alpine}'
+    image: 'clickhouse/clickhouse-server:${CLICKHOUSE_VERSION-23.2-alpine}'
     ulimits:
       nofile:
         soft: 262144
@@ -19,7 +19,7 @@ services:
       - './.docker/clickhouse/users.xml:/etc/clickhouse-server/users.xml'
 
   clickhouse2:
-    image: 'clickhouse/clickhouse-server:${CLICKHOUSE_VERSION-23.1-alpine}'
+    image: 'clickhouse/clickhouse-server:${CLICKHOUSE_VERSION-23.2-alpine}'
     ulimits:
       nofile:
         soft: 262144

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.8'
 services:
   clickhouse:
-    image: 'clickhouse/clickhouse-server:${CLICKHOUSE_VERSION-23.1-alpine}'
+    image: 'clickhouse/clickhouse-server:${CLICKHOUSE_VERSION-23.2-alpine}'
     container_name: 'clickhouse-js-clickhouse-server'
     ports:
       - '8123:8123'

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export default '0.0.13'
+export default '0.0.14'


### PR DESCRIPTION
## Summary
Prepare 0.0.14 release with the changeset from #142 

## Checklist
- [x] Unit and integration tests covering the common scenarios were added
- [x] A human-readable description of the changes was provided to include in CHANGELOG
- [x] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials https://github.com/ClickHouse/clickhouse-docs/pull/925
