### PR TITLE
Fix timeout error on nodejs 19/nodejs 20

### DIFF
--- a/src/connection/adapter/base_http_adapter.ts
+++ b/src/connection/adapter/base_http_adapter.ts
@@ -115,7 +115,9 @@ export abstract class BaseHttpAdapter implements Connection {
       const start = Date.now()
 
       const request = this.createClientRequest(params.url, params)
-
+      request.once('socket', (socket) => {
+        socket.setTimeout(this.config.request_timeout)
+      })
       function onError(err: Error): void {
         removeRequestListeners()
         reject(err)


### PR DESCRIPTION
This somehow related to use of agent and bug in nodejs https://github.com/nodejs/node/issues/47137

## Summary
Unexpected timeouts on nodejs 19 and nodejs 20 for long running queries (taking more then 3 seconds to execute)
I have reported this issue in https://github.com/ClickHouse/clickhouse-js/issues/149

