### PR TITLE
Run tests with Node.js 16/18/20

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,7 +37,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        node: [ 14, 16, 18, 19 ]
+        node: [ 16, 18, 20 ]
     steps:
       - uses: actions/checkout@main
 
@@ -68,7 +68,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        node: [ 14, 16, 18, 19 ]
+        node: [ 16, 18, 20 ]
         clickhouse: [ head, latest ]
 
     steps:
@@ -117,7 +117,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        node: [ 14, 16, 18, 19 ]
+        node: [ 16, 18, 20 ]
         clickhouse: [ head, latest ]
 
     steps:
@@ -150,7 +150,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        node: [ 14, 16, 18, 19 ]
+        node: [ 16, 18, 20 ]
 
     steps:
       - uses: actions/checkout@main

--- a/__tests__/integration/abort_request.test.ts
+++ b/__tests__/integration/abort_request.test.ts
@@ -99,7 +99,7 @@ describe('abort request', () => {
       // There was a breaking change in Node.js 18.x+ behavior
       if (
         process.version.startsWith('v18') ||
-        process.version.startsWith('v19')
+        process.version.startsWith('v20')
       ) {
         await expect(selectPromise).rejects.toMatchObject({
           message: 'Premature close',

--- a/__tests__/tls/tls.test.ts
+++ b/__tests__/tls/tls.test.ts
@@ -77,7 +77,7 @@ describe('TLS connection', () => {
       },
     })
     const errorMessage =
-      process.version.startsWith('v18') || process.version.startsWith('v19')
+      process.version.startsWith('v18') || process.version.startsWith('v20')
         ? 'unsupported certificate'
         : 'socket hang up'
     await expect(


### PR DESCRIPTION
Node.js 14.x EOL.
19.x is EOL soon too, so let's drop it as well.