### PR TITLE
Fix NULL parameters binding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.0.16
+* Fix NULL parameter binding.
+As HTTP interface expects `\N` instead of `'NULL'` string, it is now correctly handled for both `null`
+and _explicitly_ `undefined` parameters. See the [test scenarios](https://github.com/ClickHouse/clickhouse-js/blob/f1500e188600d85ddd5ee7d2a80846071c8cf23e/__tests__/integration/select_query_binding.test.ts#L273-L303) for more details.
+
 ## 0.0.15
 
 ### Bug fixes

--- a/__tests__/unit/format_query_params.test.ts
+++ b/__tests__/unit/format_query_params.test.ts
@@ -22,6 +22,10 @@ describe('formatQueryParams', () => {
     expect(formatQueryParams(null)).toBe('\\N')
   })
 
+  it('formats undefined', () => {
+    expect(formatQueryParams(undefined)).toBe('\\N')
+  })
+
   it('formats boolean', () => {
     expect(formatQueryParams(true)).toBe('1')
     expect(formatQueryParams(false)).toBe('0')

--- a/__tests__/unit/format_query_params.test.ts
+++ b/__tests__/unit/format_query_params.test.ts
@@ -19,7 +19,7 @@ function convertDateToTimezone(date: Date, tz: string) {
 
 describe('formatQueryParams', () => {
   it('formats null', () => {
-    expect(formatQueryParams(null)).toBe('NULL')
+    expect(formatQueryParams(null)).toBe('\\N')
   })
 
   it('formats boolean', () => {
@@ -114,14 +114,5 @@ describe('formatQueryParams', () => {
         params: { refs: [44] },
       })
     ).toBe("{'name':'custom','id':42,'params':{'refs':[44]}}")
-  })
-
-  it('throws on unsupported values', () => {
-    expect(() => formatQueryParams(undefined)).toThrowError(
-      'Unsupported value in query parameters: [undefined].'
-    )
-    expect(() => formatQueryParams(undefined)).toThrowError(
-      'Unsupported value in query parameters: [undefined].'
-    )
   })
 })

--- a/src/data_formatter/format_query_params.ts
+++ b/src/data_formatter/format_query_params.ts
@@ -23,7 +23,7 @@ export function formatQueryParams(
   value: any,
   wrapStringInQuotes = false
 ): string {
-  if (value === null) return 'NULL'
+  if (value === null || value === undefined) return '\\N'
   if (Number.isNaN(value)) return 'nan'
   if (value === Number.POSITIVE_INFINITY) return '+inf'
   if (value === Number.NEGATIVE_INFINITY) return '-inf'

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export default '0.0.15'
+export default '0.0.16'


### PR DESCRIPTION
## Summary
The issue was reported some time ago in the community Slack. NULL has to be passed as an actual null symbol (`\N`) instead of a string `'NULL'`. [See a similar fix in clickhouse-connect](https://github.com/ClickHouse/clickhouse-connect/pull/166/files#diff-b324bcc9f3a437c5fd9d073c6d2f04d74a4b598fe631594410f6abe9e0993c04R450).

## Checklist
- [x] Unit and integration tests covering the common scenarios were added
- [x] A human-readable description of the changes was provided to include in CHANGELOG
