### PR TITLE
Add support for URL connection string in ClickHouse client

### DIFF
--- a/__tests__/unit/client.test.ts
+++ b/__tests__/unit/client.test.ts
@@ -2,27 +2,28 @@ import type { ClickHouseClientConfigOptions } from '../../src'
 import { createClient } from '../../src'
 
 describe('createClient', () => {
-  it('throws on incorrect "host" config value', () => {
+  it('throws on incorrect "host" or "url" config value', () => {
     expect(() => createClient({ host: 'foo' })).toThrowError(
-      'Configuration parameter "host" contains malformed url.'
+      'Configuration parameter "host" or "url" contains malformed url.'
     )
   })
 
-  it('should not mutate provided configuration', async () => {
+  it('should accept url connection string and not mutate provided configuration', async () => {
     const config: ClickHouseClientConfigOptions = {
-      host: 'http://localhost',
+      url: 'clickhouse://default:password@localhost/default',
+      password: 'foobar',
     }
     createClient(config)
     // none of the initial configuration settings are overridden
     // by the defaults we assign when we normalize the specified config object
     expect(config).toEqual({
-      host: 'http://localhost',
+      url: 'clickhouse://default:password@localhost/default',
       request_timeout: undefined,
       max_open_connections: undefined,
       tls: undefined,
       compression: undefined,
       username: undefined,
-      password: undefined,
+      password: 'foobar',
       application: undefined,
       database: undefined,
       clickhouse_settings: undefined,

--- a/__tests__/unit/client.test.ts
+++ b/__tests__/unit/client.test.ts
@@ -2,9 +2,15 @@ import type { ClickHouseClientConfigOptions } from '../../src'
 import { createClient } from '../../src'
 
 describe('createClient', () => {
-  it('throws on incorrect "host" or "url" config value', () => {
+  it('throws on incorrect "host" config value', () => {
     expect(() => createClient({ host: 'foo' })).toThrowError(
-      'Configuration parameter "host" or "url" contains malformed url.'
+      'Configuration parameter "host" contains malformed url.'
+    )
+  })
+
+  it('throws on incorrect "url" config value', () => {
+    expect(() => createClient({ url: 'bar' })).toThrowError(
+      'Configuration parameter "url" contains malformed url.'
     )
   })
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -139,13 +139,11 @@ function validateConfig({ url }: NormalizedConfig): void {
   // TODO add SSL validation
 }
 
-function createUrl(url: string): URL {
+function createUrl(url: string, type: 'host' | 'url'): URL {
   try {
     return new URL(url)
   } catch (err) {
-    throw new Error(
-      'Configuration parameter "host" or "url" contains malformed url.'
-    )
+    throw new Error(`Configuration parameter "${type}" contains malformed url.`)
   }
 }
 
@@ -165,12 +163,13 @@ function normalizeConfig(config: ClickHouseClientConfigOptions) {
     }
   }
 
-  const url = config.url && createUrl(config.url)
+  const url = config.url && createUrl(config.url, 'url')
 
   return {
     application_id: config.application,
     url: createUrl(
-      config.host ?? (url && `http://${url.host}`) ?? 'http://localhost:8123'
+      config.host ?? (url && `http://${url.host}`) ?? 'http://localhost:8123',
+      'host'
     ),
     request_timeout: config.request_timeout ?? 300_000,
     max_open_connections: config.max_open_connections ?? Infinity,

--- a/src/client.ts
+++ b/src/client.ts
@@ -180,7 +180,7 @@ function normalizeConfig(config: ClickHouseClientConfigOptions) {
     },
     username: config.username ?? (url && url.username) ?? 'default',
     password: config.password ?? (url && url.password) ?? '',
-    database: config.database ?? (url && url.pathname) ?? 'default',
+    database: config.database ?? (url && url.pathname.slice(1)) ?? 'default',
     clickhouse_settings:
       config.clickhouse_settings ??
       (url && Object.fromEntries(url.searchParams)) ??


### PR DESCRIPTION
After clickhouse-client added connection string support (https://github.com/ClickHouse/ClickHouse/pull/50689) there is now nothing stops to add same support to this client.

## Summary
This pull request add support for URL connection string in ClickHouse client.

Extended the ClickHouse client configuration to accept a URL connection string which can contain user info, hosts and ports, database name and query parameters. This change provides flexible and standard connections setup. Updated related unit tests to reflect this change.

## Checklist
Delete items not relevant to your PR:
- [x] Unit and integration tests covering the common scenarios were added
- [x] A human-readable description of the changes was provided to include in CHANGELOG

