### PR TITLE
Serialize Date objects as Unix timestamps to handle different time zones

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## Unreleased
+
+### Breaking changes
+
+Date objects in query parameters are now serialized as time-zone-agnostic Unix timestamps (NNNNNNNNNN[.NNN], optionally with millisecond-precision) instead of datetime strings without time zones (YYYY-MM-DD HH:MM:SS[.MMM]). This means the server will receive the same absolute timestamp the client sent even if the client's time zone and the database server's time zone differ. Previously, if the server used one time zone and the client used another, Date objects would be encoded in the client's time zone and decoded in the server's time zone and create a mismatch.
+
+For instance, if the server used UTC (GMT) and the client used PST (GMT-8), a Date object for "2023-01-01 13:00:00 **PST**" would be encoded as "2023-01-01 13:00:00.000" and decoded as "2023-01-01 13:00:00 **UTC**" (which is 2023-01-01 **05**:00:00 PST). Now, "2023-01-01 13:00:00 PST" is encoded as "1672606800000" and decoded as "2023-01-01 **21**:00:00 UTC", the same time the client sent.
+
 ## 0.2.0 (web platform support)
 
 Introduces web client (using native [fetch](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API)

--- a/packages/client-common/__tests__/integration/select_query_binding.test.ts
+++ b/packages/client-common/__tests__/integration/select_query_binding.test.ts
@@ -68,7 +68,7 @@ describe('select with query binding', () => {
         query: 'SELECT toDate({min_time: DateTime})',
         format: 'CSV',
         query_params: {
-          min_time: new Date(2022, 4, 2),
+          min_time: new Date(Date.UTC(2022, 4, 2)),
         },
       })
 
@@ -81,7 +81,7 @@ describe('select with query binding', () => {
         query: 'SELECT toDateTime({min_time: DateTime})',
         format: 'CSV',
         query_params: {
-          min_time: new Date(2022, 4, 2, 13, 25, 55),
+          min_time: new Date(Date.UTC(2022, 4, 2, 13, 25, 55)),
         },
       })
 
@@ -94,7 +94,7 @@ describe('select with query binding', () => {
         query: 'SELECT toDateTime64({min_time: DateTime64(3)}, 3)',
         format: 'CSV',
         query_params: {
-          min_time: new Date(2022, 4, 2, 13, 25, 55, 789),
+          min_time: new Date(Date.UTC(2022, 4, 2, 13, 25, 55, 789)),
         },
       })
 

--- a/packages/client-common/__tests__/unit/format_query_params.test.ts
+++ b/packages/client-common/__tests__/unit/format_query_params.test.ts
@@ -1,24 +1,5 @@
 import { formatQueryParams } from '@clickhouse/client-common'
 
-// JS always creates Date object in local timezone,
-// so we might need to convert the date to another timezone
-function convertDateToTimezone(date: Date, tz: string) {
-  const converted = new Date(
-    date.toLocaleString('en-US', {
-      timeZone: tz,
-      year: 'numeric',
-      month: 'numeric',
-      day: 'numeric',
-      hour: 'numeric',
-      minute: 'numeric',
-      second: 'numeric',
-      // fractionalSecondDigits is not supported well in FF
-    })
-  )
-  converted.setMilliseconds(date.getMilliseconds())
-  return converted
-}
-
 describe('formatQueryParams', () => {
   it('formats null', () => {
     expect(formatQueryParams(null)).toBe('\\N')
@@ -56,39 +37,27 @@ describe('formatQueryParams', () => {
   })
 
   it('formats a date without timezone', () => {
-    const date = convertDateToTimezone(
-      new Date(Date.UTC(2022, 6, 29, 7, 52, 14)),
-      'UTC'
-    )
+    const date = new Date(Date.UTC(2022, 6, 29, 7, 52, 14))
 
-    expect(formatQueryParams(date)).toBe('2022-07-29 07:52:14')
+    expect(formatQueryParams(date)).toBe('1659081134000')
+  })
+
+  it('formats a date with only nine digits in its Unix timestamp (seconds)', () => {
+    const date = new Date(Date.UTC(1973, 10, 29, 21, 33, 9))
+
+    expect(formatQueryParams(date)).toBe('0123456789000')
   })
 
   it('formats a date with millis', () => {
     expect(
-      formatQueryParams(
-        convertDateToTimezone(
-          new Date(Date.UTC(2022, 6, 29, 7, 52, 14, 123)),
-          'UTC'
-        )
-      )
-    ).toBe('2022-07-29 07:52:14.123')
+      formatQueryParams(new Date(Date.UTC(2022, 6, 29, 7, 52, 14, 123)))
+    ).toBe('1659081134123')
     expect(
-      formatQueryParams(
-        convertDateToTimezone(
-          new Date(Date.UTC(2022, 6, 29, 7, 52, 14, 42)),
-          'UTC'
-        )
-      )
-    ).toBe('2022-07-29 07:52:14.042')
+      formatQueryParams(new Date(Date.UTC(2022, 6, 29, 7, 52, 14, 42)))
+    ).toBe('1659081134042')
     expect(
-      formatQueryParams(
-        convertDateToTimezone(
-          new Date(Date.UTC(2022, 6, 29, 7, 52, 14, 5)),
-          'UTC'
-        )
-      )
-    ).toBe('2022-07-29 07:52:14.005')
+      formatQueryParams(new Date(Date.UTC(2022, 6, 29, 7, 52, 14, 5)))
+    ).toBe('1659081134005')
   })
 
   it('does not wrap a string in quotes', () => {

--- a/packages/client-common/__tests__/unit/format_query_params.test.ts
+++ b/packages/client-common/__tests__/unit/format_query_params.test.ts
@@ -39,25 +39,25 @@ describe('formatQueryParams', () => {
   it('formats a date without timezone', () => {
     const date = new Date(Date.UTC(2022, 6, 29, 7, 52, 14))
 
-    expect(formatQueryParams(date)).toBe('1659081134000')
+    expect(formatQueryParams(date)).toBe('1659081134')
   })
 
   it('formats a date with only nine digits in its Unix timestamp (seconds)', () => {
     const date = new Date(Date.UTC(1973, 10, 29, 21, 33, 9))
 
-    expect(formatQueryParams(date)).toBe('0123456789000')
+    expect(formatQueryParams(date)).toBe('0123456789')
   })
 
   it('formats a date with millis', () => {
     expect(
       formatQueryParams(new Date(Date.UTC(2022, 6, 29, 7, 52, 14, 123)))
-    ).toBe('1659081134123')
+    ).toBe('1659081134.123')
     expect(
       formatQueryParams(new Date(Date.UTC(2022, 6, 29, 7, 52, 14, 42)))
-    ).toBe('1659081134042')
+    ).toBe('1659081134.042')
     expect(
       formatQueryParams(new Date(Date.UTC(2022, 6, 29, 7, 52, 14, 5)))
-    ).toBe('1659081134005')
+    ).toBe('1659081134.005')
   })
 
   it('does not wrap a string in quotes', () => {

--- a/packages/client-common/src/data_formatter/format_query_params.ts
+++ b/packages/client-common/src/data_formatter/format_query_params.ts
@@ -1,24 +1,5 @@
 import { replaceAll } from '../utils'
 
-function withPadding(value: number): string {
-  if (value > 9) return String(value)
-  return `0${value}`
-}
-
-function formatMillis(value: Date) {
-  const ms = value.getMilliseconds()
-  if (ms === 0) {
-    return ''
-  }
-  if (ms > 99) {
-    return `.${ms}`
-  }
-  if (ms > 9) {
-    return `.0${ms}`
-  }
-  return `.00${ms}`
-}
-
 export function formatQueryParams(
   value: any,
   wrapStringInQuotes = false
@@ -41,16 +22,14 @@ export function formatQueryParams(
   }
 
   if (value instanceof Date) {
-    // TODO add timezone support
-    const date = `${value.getFullYear()}-${withPadding(
-      value.getMonth() + 1
-    )}-${withPadding(value.getDate())}`
-    const time = `${withPadding(value.getHours())}:${withPadding(
-      value.getMinutes()
-    )}:${withPadding(value.getSeconds())}`
-
-    const ms = formatMillis(value)
-    return `${date} ${time}${ms}`
+    // The ClickHouse server parses numbers as time-zone-agnostic Unix timestamps
+    const unixTimestamp = Math.floor(value.getTime() / 1000)
+      .toString()
+      .padStart(10, '0')
+    const milliseconds = value.getUTCMilliseconds()
+    return milliseconds === 0
+      ? unixTimestamp
+      : `${unixTimestamp}.${milliseconds.toString().padStart(3, '0')}`
   }
 
   if (typeof value === 'object') {


### PR DESCRIPTION
## Summary
Date objects in query parameters are now serialized as time-zone-agnostic Unix timestamps (NNNNNNNNNN[.NNN], optionally with millisecond-precision) instead of datetime strings without time zones (YYYY-MM-DD HH:MM:SS[.MMM]). This means the server will receive the same absolute timestamp the client sent even if the client's time zone and the database server's time zone differ. Previously, if the server used one time zone and the client used another, Date objects would be encoded in the client's time zone and decoded in the server's time zone and create a mismatch.

For instance, if the server used UTC (GMT) and the client used PST (GMT-8), a Date object for "2023-01-01 13:00:00 **PST**" would be encoded as "2023-01-01 13:00:00.000" and decoded as "2023-01-01 13:00:00 **UTC**" (which is 2023-01-01 **05**:00:00 PST). Now, "2023-01-01 13:00:00 PST" is encoded as "1672606800" and decoded as "2023-01-01 **21**:00:00 UTC", the same time the client sent.

As far as I can tell, this is almost always the preferred behavior. Should a user need the old behavior, they can manually convert Dates to strings before passing them in as query parameters.

Both unit tests and integration tests pass. Because the client's time zone is now accounted for, the test cases use `Date.UTC()` so they pass even if the computer running the tests is not using UTC.

## Checklist
---
Delete items not relevant to your PR:
- [x] Unit and integration tests covering the common scenarios were added
- [x] A human-readable description of the changes was provided to include in CHANGELOG