### PR TITLE
Drain insert HTTP response

### DIFF
--- a/packages/client-node/src/connection/node_base_connection.ts
+++ b/packages/client-node/src/connection/node_base_connection.ts
@@ -354,6 +354,40 @@ export abstract class NodeBaseConnection
     }
   }
 
+  async drainHttpResponse(stream: Stream.Readable): Promise<void> {
+    return new Promise((resolve, reject) => {
+      function dropdata() {
+        // We don't care about the data
+      }
+
+      function onEnd() {
+        removeListeners()
+        resolve()
+      }
+
+      function onError(err: Error) {
+        removeListeners()
+        reject(err)
+      }
+
+      function onClose() {
+        removeListeners()
+      }
+
+      function removeListeners() {
+        stream.removeListener('data', dropdata)
+        stream.removeListener('end', onEnd)
+        stream.removeListener('error', onError)
+        stream.removeListener('onClose', onClose)
+      }
+
+      stream.on('data', dropdata)
+      stream.on('end', onEnd)
+      stream.on('error', onError)
+      stream.on('close', onClose)
+    })
+  }
+
   async insert(
     params: ConnInsertParams<Stream.Readable>
   ): Promise<ConnInsertResult> {
@@ -375,7 +409,7 @@ export abstract class NodeBaseConnection
       compress_request: this.params.compression.compress_request,
     })
 
-    stream.destroy()
+    await this.drainHttpResponse(stream)
     return { query_id }
   }
 

--- a/packages/client-node/src/connection/node_base_connection.ts
+++ b/packages/client-node/src/connection/node_base_connection.ts
@@ -356,7 +356,7 @@ export abstract class NodeBaseConnection
 
   async drainHttpResponse(stream: Stream.Readable): Promise<void> {
     return new Promise((resolve, reject) => {
-      function dropdata() {
+      function dropData() {
         // We don't care about the data
       }
 
@@ -375,13 +375,13 @@ export abstract class NodeBaseConnection
       }
 
       function removeListeners() {
-        stream.removeListener('data', dropdata)
+        stream.removeListener('data', dropData)
         stream.removeListener('end', onEnd)
         stream.removeListener('error', onError)
         stream.removeListener('onClose', onClose)
       }
 
-      stream.on('data', dropdata)
+      stream.on('data', dropData)
       stream.on('end', onEnd)
       stream.on('error', onError)
       stream.on('close', onClose)


### PR DESCRIPTION
In case of an insert call drain the HTTP response instead of destroying it. 

## Summary
Calling destroy eventually closed the socket even if keep-alive was set. This was a performance limitation.
https://github.com/ClickHouse/clickhouse-js/issues/202

## Checklist
Delete items not relevant to your PR:

Note: I don't know how to test this
- [ ] Unit and integration tests covering the common scenarios were added

Note: I don't know if it applies to my change
- [ ] A human-readable description of the changes was provided to include in CHANGELOG

