### PR TITLE
Don't override `pathname` in `transformUrl`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.2.5 (Common, Node.js, Web)
+
+### Bug fixes
+
+- `pathname` segment from `host` client configuration parameter is now handled properly when making requests.
+  See this [comment](https://github.com/ClickHouse/clickhouse-js/issues/164#issuecomment-1785166626) for more details.
+
 ## 0.2.4 (Node.js only)
 
 No changes in web/common modules.

--- a/packages/client-common/__tests__/unit/transform_url.test.ts
+++ b/packages/client-common/__tests__/unit/transform_url.test.ts
@@ -45,6 +45,14 @@ describe('transformUrl', () => {
     expect(newUrl.toString()).toBe('http://clickhouse.com/clickhouse/foobar')
   })
 
+  it('allows a trailing slash in the pathname', () => {
+    const url = new URL('http://clickhouse.com/clickhouse/')
+    const newUrl = transformUrl({
+      url,
+    })
+    expect(newUrl.toString()).toBe('http://clickhouse.com/clickhouse/')
+  })
+
   it('does not mutate an original url', () => {
     const url = new URL('http://clickhouse.com')
     const newUrl = transformUrl({

--- a/packages/client-common/__tests__/unit/transform_url.test.ts
+++ b/packages/client-common/__tests__/unit/transform_url.test.ts
@@ -1,6 +1,22 @@
 import { transformUrl } from '@clickhouse/client-common'
 
 describe('transformUrl', () => {
+  it('only adds the trailing slash to a url without pathname', () => {
+    const url = new URL('http://clickhouse.com')
+    const newUrl = transformUrl({
+      url,
+    })
+    expect(newUrl.toString()).toBe('http://clickhouse.com/')
+  })
+
+  it('does nothing with a url with pathname', () => {
+    const url = new URL('http://clickhouse.com/clickhouse')
+    const newUrl = transformUrl({
+      url,
+    })
+    expect(newUrl.toString()).toBe('http://clickhouse.com/clickhouse')
+  })
+
   it('attaches pathname and search params to the url', () => {
     const url = new URL('http://clickhouse.com')
     const newUrl = transformUrl({
@@ -18,6 +34,15 @@ describe('transformUrl', () => {
       pathname: 'foo',
     })
     expect(newUrl.toString()).toBe('http://clickhouse.com/foo')
+  })
+
+  it('attaches pathname to an existing pathname', () => {
+    const url = new URL('http://clickhouse.com/clickhouse')
+    const newUrl = transformUrl({
+      url,
+      pathname: '/foobar',
+    })
+    expect(newUrl.toString()).toBe('http://clickhouse.com/clickhouse/foobar')
   })
 
   it('does not mutate an original url', () => {

--- a/packages/client-common/src/utils/url.ts
+++ b/packages/client-common/src/utils/url.ts
@@ -1,5 +1,5 @@
-import type { ClickHouseSettings } from '../settings'
 import { formatQueryParams, formatQuerySettings } from '../data_formatter'
+import type { ClickHouseSettings } from '../settings'
 
 export function transformUrl({
   url,
@@ -13,7 +13,14 @@ export function transformUrl({
   const newUrl = new URL(url)
 
   if (pathname) {
-    newUrl.pathname = pathname
+    // See https://developer.mozilla.org/en-US/docs/Web/API/URL/pathname
+    // > value for such "special scheme" URLs can never be the empty string,
+    // > but will instead always have at least one / character.
+    if (newUrl.pathname === '/') {
+      newUrl.pathname = pathname
+    } else {
+      newUrl.pathname += pathname
+    }
   }
 
   if (searchParams) {

--- a/packages/client-common/src/version.ts
+++ b/packages/client-common/src/version.ts
@@ -1,1 +1,1 @@
-export default '0.2.4'
+export default '0.2.5'

--- a/packages/client-node/src/connection/node_base_connection.ts
+++ b/packages/client-node/src/connection/node_base_connection.ts
@@ -317,7 +317,7 @@ export abstract class NodeBaseConnection
 
     const stream = await this.request({
       method: 'POST',
-      url: transformUrl({ url: this.params.url, pathname: '/', searchParams }),
+      url: transformUrl({ url: this.params.url, searchParams }),
       body: params.query,
       abort_signal: params.abort_signal,
       decompress_response: clickhouse_settings.enable_http_compression === 1,
@@ -343,7 +343,7 @@ export abstract class NodeBaseConnection
 
     const stream = await this.request({
       method: 'POST',
-      url: transformUrl({ url: this.params.url, pathname: '/', searchParams }),
+      url: transformUrl({ url: this.params.url, searchParams }),
       body: params.query,
       abort_signal: params.abort_signal,
     })
@@ -403,7 +403,7 @@ export abstract class NodeBaseConnection
 
     const stream = await this.request({
       method: 'POST',
-      url: transformUrl({ url: this.params.url, pathname: '/', searchParams }),
+      url: transformUrl({ url: this.params.url, searchParams }),
       body: params.values,
       abort_signal: params.abort_signal,
       compress_request: this.params.compression.compress_request,

--- a/packages/client-node/src/version.ts
+++ b/packages/client-node/src/version.ts
@@ -1,1 +1,1 @@
-export default '0.2.4'
+export default '0.2.5'

--- a/packages/client-web/src/connection/web_connection.ts
+++ b/packages/client-web/src/connection/web_connection.ts
@@ -143,7 +143,7 @@ export class WebConnection implements Connection<ReadableStream> {
   }): Promise<Response> {
     const url = transformUrl({
       url: this.params.url,
-      pathname: pathname ?? '/',
+      pathname,
       searchParams,
     }).toString()
 

--- a/packages/client-web/src/version.ts
+++ b/packages/client-web/src/version.ts
@@ -1,1 +1,1 @@
-export default '0.2.4'
+export default '0.2.5'


### PR DESCRIPTION
## Summary
See the [discussion](https://github.com/ClickHouse/clickhouse-js/issues/164#issuecomment-1785166626). Before these changes, `host` such as `http://proxy:8123/clickhouse` will always lose its `/clickhouse` pathname segment after the `transformUrl` call. Now, it is preserved.

## Checklist
- [x] Unit and integration tests covering the common scenarios were added
- [x] A human-readable description of the changes was provided to include in CHANGELOG
