### PR TITLE
Expose `X-ClickHouse-Summary` header info

### DIFF
--- a/.docker/clickhouse/single_node_tls/Dockerfile
+++ b/.docker/clickhouse/single_node_tls/Dockerfile
@@ -1,4 +1,4 @@
-FROM clickhouse/clickhouse-server:23.10-alpine
+FROM clickhouse/clickhouse-server:23.11-alpine
 COPY .docker/clickhouse/single_node_tls/certificates /etc/clickhouse-server/certs
 RUN chown clickhouse:clickhouse -R /etc/clickhouse-server/certs \
     && chmod 600 /etc/clickhouse-server/certs/* \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,11 @@
-## 0.2.7 (Web only)
+## 0.2.7 (Common, Node.js, Web)
+
+### New features
+
+- (Node.js only) `X-ClickHouse-Summary` response header is now parsed when working with `insert`/`exec`/`command` methods.
+  See the [related test](./packages/client-node/__tests__/integration/node_summary.test.ts) for more details.
+  NB: it is guaranteed to be correct only for non-streaming scenarios.
+  Web version does not currently support this due to CORS limitations. ([#210](https://github.com/ClickHouse/clickhouse-js/issues/210))
 
 ### Bug fixes
 

--- a/docker-compose.cluster.yml
+++ b/docker-compose.cluster.yml
@@ -2,7 +2,7 @@ version: '2.3'
 
 services:
   clickhouse1:
-    image: 'clickhouse/clickhouse-server:${CLICKHOUSE_VERSION-23.10-alpine}'
+    image: 'clickhouse/clickhouse-server:${CLICKHOUSE_VERSION-23.11-alpine}'
     ulimits:
       nofile:
         soft: 262144
@@ -19,7 +19,7 @@ services:
       - './.docker/clickhouse/users.xml:/etc/clickhouse-server/users.xml'
 
   clickhouse2:
-    image: 'clickhouse/clickhouse-server:${CLICKHOUSE_VERSION-23.10-alpine}'
+    image: 'clickhouse/clickhouse-server:${CLICKHOUSE_VERSION-23.11-alpine}'
     ulimits:
       nofile:
         soft: 262144

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.8'
 services:
   clickhouse:
-    image: 'clickhouse/clickhouse-server:${CLICKHOUSE_VERSION-23.10-alpine}'
+    image: 'clickhouse/clickhouse-server:${CLICKHOUSE_VERSION-23.11-alpine}'
     container_name: 'clickhouse-js-clickhouse-server'
     ports:
       - '8123:8123'

--- a/karma.config.cjs
+++ b/karma.config.cjs
@@ -4,7 +4,7 @@ const TEST_TIMEOUT_MS = 120_000
 
 module.exports = function (config) {
   config.set({
-    // base path that will be used to resolve all patterns (eg. files, exclude)
+    // base path that will be used to resolve all patterns (e.g. files, exclude)
     basePath: '',
     frameworks: ['webpack', 'jasmine'],
     // list of files / patterns to load in the browser

--- a/packages/client-common/__tests__/integration/data_types.test.ts
+++ b/packages/client-common/__tests__/integration/data_types.test.ts
@@ -401,7 +401,9 @@ describe('data types', () => {
     ).toEqual('3\n')
   })
 
-  it('should work with geo', async () => {
+  // FIXME: somehow broken after, probably, https://github.com/ClickHouse/ClickHouse/pull/56724
+  //  enable once resolved.
+  xit('should work with geo', async () => {
     const values = [
       {
         p: [42, 144],

--- a/packages/client-common/__tests__/integration/data_types.test.ts
+++ b/packages/client-common/__tests__/integration/data_types.test.ts
@@ -401,9 +401,7 @@ describe('data types', () => {
     ).toEqual('3\n')
   })
 
-  // FIXME: somehow broken after, probably, https://github.com/ClickHouse/ClickHouse/pull/56724
-  //  enable once resolved.
-  xit('should work with geo', async () => {
+  it('should work with geo', async () => {
     const values = [
       {
         p: [42, 144],

--- a/packages/client-common/__tests__/integration/insert.test.ts
+++ b/packages/client-common/__tests__/integration/insert.test.ts
@@ -8,7 +8,7 @@ describe('insert', () => {
   let tableName: string
 
   beforeEach(async () => {
-    client = await createTestClient()
+    client = createTestClient()
     tableName = `insert_test_${guid()}`
     await createSimpleTable(client, tableName)
   })

--- a/packages/client-common/src/clickhouse_types.ts
+++ b/packages/client-common/src/clickhouse_types.ts
@@ -16,3 +16,18 @@ export interface InputJSON<T = unknown> {
 }
 
 export type InputJSONObjectEachRow<T = unknown> = Record<string, T>
+
+export interface ClickHouseSummary {
+  read_rows: string
+  read_bytes: string
+  written_rows: string
+  written_bytes: string
+  total_rows_to_read: string
+  result_rows: string
+  result_bytes: string
+  elapsed_ns: string
+}
+
+export interface WithClickHouseSummary {
+  summary?: ClickHouseSummary
+}

--- a/packages/client-common/src/client.ts
+++ b/packages/client-common/src/client.ts
@@ -4,8 +4,9 @@ import type {
   Connection,
   ConnectionParams,
   ConnInsertResult,
-  ConnQueryResult,
   Logger,
+  WithClickHouseSummary,
+  ConnExecResult,
 } from '@clickhouse/client-common'
 import {
   type DataFormat,
@@ -76,7 +77,7 @@ export interface ClickHouseClientConfigOptions<Stream> {
   username?: string
   /** The user password. Default: ''. */
   password?: string
-  /** The name of the application using the nodejs client.
+  /** The name of the application using the JS client.
    * Default: empty. */
   application?: string
   /** Database name to use. Default value: `default`. */
@@ -124,12 +125,10 @@ export interface ExecParams extends BaseQueryParams {
 }
 
 export type CommandParams = ExecParams
-export interface CommandResult {
-  query_id: string
-}
+export type CommandResult = { query_id: string } & WithClickHouseSummary
 
 export type InsertResult = ConnInsertResult
-export type ExecResult<Stream> = ConnQueryResult<Stream>
+export type ExecResult<Stream> = ConnExecResult<Stream>
 export type PingResult = ConnPingResult
 
 export type InsertValues<Stream, T = unknown> =
@@ -203,9 +202,9 @@ export class ClickHouseClient<Stream = unknown> {
    * If you are interested in the response data, consider using {@link ClickHouseClient.exec}
    */
   async command(params: CommandParams): Promise<CommandResult> {
-    const { stream, query_id } = await this.exec(params)
+    const { stream, query_id, summary } = await this.exec(params)
     await this.closeStream(stream)
-    return { query_id }
+    return { query_id, summary }
   }
 
   /**

--- a/packages/client-common/src/connection.ts
+++ b/packages/client-common/src/connection.ts
@@ -1,3 +1,4 @@
+import type { WithClickHouseSummary } from './clickhouse_types'
 import type { LogWriter } from './logger'
 import type { ClickHouseSettings } from './settings'
 
@@ -39,8 +40,9 @@ export interface ConnQueryResult<Stream> extends ConnBaseResult {
   query_id: string
 }
 
-export type ConnInsertResult = ConnBaseResult
-export type ConnExecResult<Stream> = ConnQueryResult<Stream>
+export type ConnInsertResult = ConnBaseResult & WithClickHouseSummary
+export type ConnExecResult<Stream> = ConnQueryResult<Stream> &
+  WithClickHouseSummary
 
 export type ConnPingResult =
   | {

--- a/packages/client-common/src/index.ts
+++ b/packages/client-common/src/index.ts
@@ -24,6 +24,8 @@ export {
   type LogParams,
 } from './logger'
 export type {
+  ClickHouseSummary,
+  WithClickHouseSummary,
   ResponseJSON,
   InputJSON,
   InputJSONObjectEachRow,

--- a/packages/client-node/__tests__/integration/node_summary.test.ts
+++ b/packages/client-node/__tests__/integration/node_summary.test.ts
@@ -13,7 +13,7 @@ describe('[Node.js] Summary header parsing', () => {
     tableName = `summary_test_${guid()}`
     await createSimpleTable(client, tableName)
   })
-  afterEach(async () => {
+  afterAll(async () => {
     await client.close()
   })
 

--- a/packages/client-node/__tests__/integration/node_summary.test.ts
+++ b/packages/client-node/__tests__/integration/node_summary.test.ts
@@ -1,0 +1,70 @@
+import type { ClickHouseClient } from '@clickhouse/client-common'
+import { createSimpleTable } from '@test/fixtures/simple_table'
+import { jsonValues } from '@test/fixtures/test_data'
+import { createTestClient, guid } from '@test/utils'
+import type Stream from 'stream'
+
+describe('[Node.js] Summary header parsing', () => {
+  let client: ClickHouseClient<Stream.Readable>
+  let tableName: string
+
+  beforeAll(async () => {
+    client = createTestClient()
+    tableName = `summary_test_${guid()}`
+    await createSimpleTable(client, tableName)
+  })
+  afterEach(async () => {
+    await client.close()
+  })
+
+  it('should provide summary for insert/exec', async () => {
+    const { summary: insertSummary } = await client.insert({
+      table: tableName,
+      values: jsonValues,
+      format: 'JSONEachRow',
+    })
+    expect(insertSummary).toEqual({
+      read_rows: '5',
+      read_bytes: jasmine.any(String),
+      written_rows: '5',
+      written_bytes: jasmine.any(String),
+      total_rows_to_read: '0',
+      result_rows: '5',
+      result_bytes: jasmine.any(String),
+      elapsed_ns: jasmine.any(String),
+    })
+
+    const { summary: execSummary } = await client.exec({
+      query: `INSERT INTO ${tableName} SELECT * FROM ${tableName}`,
+    })
+    expect(execSummary).toEqual({
+      read_rows: '5',
+      read_bytes: jasmine.any(String),
+      written_rows: '5',
+      written_bytes: jasmine.any(String),
+      total_rows_to_read: '5',
+      result_rows: '5',
+      result_bytes: jasmine.any(String),
+      elapsed_ns: jasmine.any(String),
+    })
+  })
+
+  it('should provide summary for command', async () => {
+    const { summary } = await client.command({
+      query: `INSERT INTO ${tableName} VALUES (144, 'Hello', [2, 4]), (255, 'World', [3, 5])`,
+      clickhouse_settings: {
+        wait_end_of_query: 1,
+      },
+    })
+    expect(summary).toEqual({
+      read_rows: '2',
+      read_bytes: jasmine.any(String),
+      written_rows: '2',
+      written_bytes: jasmine.any(String),
+      total_rows_to_read: '0',
+      result_rows: '2',
+      result_bytes: jasmine.any(String),
+      elapsed_ns: jasmine.any(String),
+    })
+  })
+})


### PR DESCRIPTION
## Summary
* Adds `summary` field to `insert`/`exec`/`command` result, which is parsed from the `X-ClickHouse-Summary` response header.
* Geo data type test is temporarily marked as ignored as it is still unclear why it fails with a cluster setup on the latest master.

Node.js only. The web version seems to have some CORS limitations.

Question: shall we expose `summary` for `query`, too? It is very unlikely to be correct with streaming scenarios, and for non-streaming ones, we know the number of rows anyway.

Resolves #210 

## Checklist
- [x] Unit and integration tests covering the common scenarios were added
- [x] A human-readable description of the changes was provided to include in CHANGELOG
