### PR TITLE
Make keep_alive configurable in the Web version

### DIFF
--- a/packages/client-web/__tests__/integration/web_connection.test.ts
+++ b/packages/client-web/__tests__/integration/web_connection.test.ts
@@ -1,0 +1,42 @@
+import { createClient } from '../../src'
+import type { WebClickHouseClient } from '../../src/client'
+
+describe('[Web] Connection', () => {
+  let fetchSpy: jasmine.Spy<typeof window.fetch>
+  beforeEach(() => {
+    fetchSpy = spyOn(window, 'fetch').and.returnValue(
+      Promise.resolve(stubResponse())
+    )
+  })
+
+  describe('KeepAlive setting', () => {
+    it('should be enabled by default', async () => {
+      const client = createClient()
+      const fetchParams = await pingAndGetRequestInit(client)
+      expect(fetchParams.keepalive).toBeTruthy()
+    })
+
+    it('should be possible to disable it', async () => {
+      const client = createClient({ keep_alive: { enabled: false } })
+      const fetchParams = await pingAndGetRequestInit(client)
+      expect(fetchParams!.keepalive).toBeFalsy()
+    })
+
+    it('should be enabled with an explicit setting', async () => {
+      const client = createClient({ keep_alive: { enabled: true } })
+      const fetchParams = await pingAndGetRequestInit(client)
+      expect(fetchParams.keepalive).toBeTruthy()
+    })
+
+    async function pingAndGetRequestInit(client: WebClickHouseClient) {
+      await client.ping()
+      expect(fetchSpy).toHaveBeenCalledTimes(1)
+      const [, fetchParams] = fetchSpy.calls.mostRecent().args
+      return fetchParams!
+    }
+  })
+
+  function stubResponse() {
+    return new Response()
+  }
+})

--- a/packages/client-web/__tests__/integration/web_connection.test.ts
+++ b/packages/client-web/__tests__/integration/web_connection.test.ts
@@ -2,14 +2,14 @@ import { createClient } from '../../src'
 import type { WebClickHouseClient } from '../../src/client'
 
 describe('[Web] Connection', () => {
-  let fetchSpy: jasmine.Spy<typeof window.fetch>
-  beforeEach(() => {
-    fetchSpy = spyOn(window, 'fetch').and.returnValue(
-      Promise.resolve(stubResponse())
-    )
-  })
-
   describe('KeepAlive setting', () => {
+    let fetchSpy: jasmine.Spy<typeof window.fetch>
+    beforeEach(() => {
+      fetchSpy = spyOn(window, 'fetch').and.returnValue(
+        Promise.resolve(new Response())
+      )
+    })
+
     it('should be enabled by default', async () => {
       const client = createClient()
       const fetchParams = await pingAndGetRequestInit(client)
@@ -35,8 +35,4 @@ describe('[Web] Connection', () => {
       return fetchParams!
     }
   })
-
-  function stubResponse() {
-    return new Response()
-  }
 })

--- a/packages/client-web/src/client.ts
+++ b/packages/client-web/src/client.ts
@@ -15,6 +15,14 @@ import { WebConnection } from './connection'
 import { ResultSet } from './result_set'
 import { WebValuesEncoder } from './utils'
 
+export type WebClickHouseClientConfigOptions =
+  BaseClickHouseClientConfigOptions<ReadableStream> & {
+    keep_alive?: {
+      /** Enable or disable HTTP Keep-Alive mechanism. Default: true */
+      enabled: boolean
+    }
+  }
+
 export type WebClickHouseClient = Omit<
   ClickHouseClient<ReadableStream>,
   'insert' | 'query'
@@ -30,11 +38,15 @@ export type WebClickHouseClient = Omit<
 }
 
 export function createClient(
-  config?: BaseClickHouseClientConfigOptions<ReadableStream>
+  config?: WebClickHouseClientConfigOptions
 ): WebClickHouseClient {
+  const keep_alive = {
+    enabled: config?.keep_alive?.enabled ?? true,
+  }
   return new ClickHouseClient<ReadableStream>({
     impl: {
-      make_connection: (params: ConnectionParams) => new WebConnection(params),
+      make_connection: (params: ConnectionParams) =>
+        new WebConnection({ ...params, keep_alive }),
       make_result_set: (
         stream: ReadableStream,
         format: DataFormat,

--- a/packages/client-web/src/connection/web_connection.ts
+++ b/packages/client-web/src/connection/web_connection.ts
@@ -24,9 +24,15 @@ type WebInsertParams<T> = Omit<
   values: string
 }
 
+export type WebConnectionParams = ConnectionParams & {
+  keep_alive: {
+    enabled: boolean
+  }
+}
+
 export class WebConnection implements Connection<ReadableStream> {
   private readonly defaultHeaders: Record<string, string>
-  constructor(private readonly params: ConnectionParams) {
+  constructor(private readonly params: WebConnectionParams) {
     this.defaultHeaders = {
       Authorization: `Basic ${btoa(`${params.username}:${params.password}`)}`,
     }
@@ -175,7 +181,7 @@ export class WebConnection implements Connection<ReadableStream> {
       const response = await fetch(url, {
         body: values,
         headers,
-        keepalive: false,
+        keepalive: this.params.keep_alive.enabled,
         method: method ?? 'POST',
         signal: abortController.signal,
       })


### PR DESCRIPTION
## Summary

Resolves #186. Related to https://github.com/ClickHouse/clickhouse-js/issues/211#issuecomment-1871032892.
KeepAlive was disabled for the web version without the possibility to re-enable it. 

## Checklist
- [x] Unit and integration tests covering the common scenarios were added

The changelog and the docs will be updated after #218 
