### PR TITLE
Add tests for Nested data type

### DIFF
--- a/packages/client-common/__tests__/integration/data_types.test.ts
+++ b/packages/client-common/__tests__/integration/data_types.test.ts
@@ -714,13 +714,15 @@ describe('data types', () => {
       'n Nested(id UInt32, name String, createdAt DateTime, ' +
         `roles Array(Enum('User', 'Admin')))`,
       {
-        input_format_import_nested_json: 1,
         flatten_nested: 0,
       }
     )
     await client.insert({
       table,
       values,
+      clickhouse_settings: {
+        input_format_import_nested_json: 1,
+      },
       format: 'JSONEachRow',
     })
     const result = await client


### PR DESCRIPTION
## Summary

Closes https://github.com/ClickHouse/clickhouse-js/issues/89

It looks like the `Nested` data type is already supported, but the documentation says it isn't yet supported: https://clickhouse.com/docs/en/integrations/language-clients/javascript#supported-clickhouse-data-types

https://github.com/ClickHouse/clickhouse-docs/blob/d99f31aa0e8aa50085a737ca3402f09931c75b9f/docs/en/integrations/language-clients/js.md?plain=1#L739

This may lead to confusion.

I'm adding tests to prove that it does work, so I can update the status of support in the docs

## Checklist
- [x] Unit and integration tests covering the common scenarios were added