### PR TITLE
More examples: select and insert formats overview

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -7,7 +7,7 @@ Node.JS-specific examples are located in the `examples/node` directory.
 
 ## Overview
 
-We aim to cover various scenarios of client usage with these examples.
+We aim to cover various scenarios of client usage with these examples. You should be able to run any of these examples, see [How to run](#how-to-run) section below.
 
 #### General usage
 
@@ -28,6 +28,7 @@ We aim to cover various scenarios of client usage with these examples.
 #### Inserting data
 
 - [array_json_each_row.ts](array_json_each_row.ts) - a simple insert of an array of values using `JSONEachRow` format.
+- [insert_data_formats_overview.ts](insert_data_formats_overview.ts) - an overview of available data formats for inserting data.
 - [async_insert.ts](async_insert.ts) - server-side batching using async inserts; the client will be waiting for a written batch ack.
 - [async_insert_without_waiting.ts](async_insert_without_waiting.ts) - server-side batching using async inserts; the client will not be waiting for a written batch ack. This is a bit more advanced async insert example simulating an event listener.
 - [insert_exclude_columns.ts](insert_exclude_columns.ts) - inserting into specific columns only, or excluding certain columns from the INSERT statement.
@@ -44,6 +45,7 @@ We aim to cover various scenarios of client usage with these examples.
 #### Selecting data
 
 - [select_json_each_row.ts](select_json_each_row.ts) - simple select of the data in the `JSONEachRow` format.
+- [select_data_formats_overview.ts](select_data_formats_overview.ts) - an overview of all available data formats for select queries.
 - [select_json_with_metadata.ts](select_json_with_metadata.ts) - select result as a JSON object with query metadata.
 - [query_with_parameter_binding.ts](query_with_parameter_binding.ts) - query parameter binding example.
 - [select_parquet_as_file.ts](node/select_parquet_as_file.ts) - (Node.js only) select data from ClickHouse and save it as a Parquet file. This example can be adjusted to save the data in other formats, such as CSV/TSV/TabSeparated, by changing the format in the query.

--- a/examples/insert_data_formats_overview.ts
+++ b/examples/insert_data_formats_overview.ts
@@ -1,0 +1,162 @@
+import { createClient } from '@clickhouse/client'
+import type { DataFormat } from '@clickhouse/client-common'
+import {
+  type InputJSON,
+  type InputJSONObjectEachRow,
+} from '@clickhouse/client-common'
+
+/**
+ * An overview of available formats for inserting your data, mainly in different JSON formats.
+ * For "raw" formats, such as:
+ *  - CSV
+ *  - CSVWithNames
+ *  - CSVWithNamesAndTypes
+ *  - TabSeparated
+ *  - TabSeparatedRaw
+ *  - TabSeparatedWithNames
+ *  - TabSeparatedWithNamesAndTypes
+ *  - CustomSeparated
+ *  - CustomSeparatedWithNames
+ *  - CustomSeparatedWithNamesAndTypes
+ *  - Parquet
+ *  insert method requires a Stream as its input; see the streaming examples:
+ *  - streaming from a CSV file - node/insert_file_stream_csv.ts
+ *  - streaming from a Parquet file - node/insert_file_stream_parquet.ts
+ *
+ * See also:
+ * - ClickHouse formats documentation - https://clickhouse.com/docs/en/interfaces/formats
+ * - SELECT formats overview - select_data_formats_overview.ts
+ */
+void (async () => {
+  const tableName = 'insert_data_formats_overview'
+  const client = createClient()
+  await prepareTestTable()
+
+  // These JSON formats can be streamed as well instead of sending the entire data set at once;
+  // See this example that streams a file: node/insert_file_stream_ndjson.ts
+  console.log('#### Streamable JSON formats:\n')
+  // All of these formats accept various arrays of objects, depending on the format.
+  await insertJSON('JSONEachRow', [
+    { id: 1, name: 'foo', sku: [1, 2, 3] },
+    { id: 2, name: 'bar', sku: [4, 5, 6] },
+  ])
+  await insertJSON('JSONStringsEachRow', [
+    { id: '3', name: 'foo', sku: '[1,2,3]' },
+    { id: '4', name: 'bar', sku: '[4,5,6]' },
+  ])
+  await insertJSON('JSONCompactEachRow', [
+    [5, 'foo', [1, 2, 3]],
+    [6, 'bar', [4, 5, 6]],
+  ])
+  await insertJSON('JSONCompactStringsEachRow', [
+    ['7', 'foo', '[1,2,3]'],
+    ['8', 'bar', '[4,5,6]'],
+  ])
+  await insertJSON('JSONCompactEachRowWithNames', [
+    ['id', 'name', 'sku'],
+    [9, 'foo', [1, 2, 3]],
+    [10, 'bar', [4, 5, 6]],
+  ])
+  await insertJSON('JSONCompactEachRowWithNamesAndTypes', [
+    ['id', 'name', 'sku'],
+    ['UInt32', 'String', 'Array(UInt32)'],
+    [11, 'foo', [1, 2, 3]],
+    [12, 'bar', [4, 5, 6]],
+  ])
+  await insertJSON('JSONCompactStringsEachRowWithNames', [
+    ['id', 'name', 'sku'],
+    ['13', 'foo', '[1,2,3]'],
+    ['14', 'bar', '[4,5,6]'],
+  ])
+  await insertJSON('JSONCompactStringsEachRowWithNamesAndTypes', [
+    ['id', 'name', 'sku'],
+    ['UInt32', 'String', 'Array(UInt32)'],
+    ['15', 'foo', '[1,2,3]'],
+    ['16', 'bar', '[4,5,6]'],
+  ])
+
+  // These are single document JSON formats, which are not streamable
+  console.log('\n#### Single document JSON formats:\n')
+  // JSON, JSONCompact, JSONColumnsWithMetadata accept the InputJSON<T> shape.
+  // For example: https://clickhouse.com/docs/en/interfaces/formats#json
+  const meta: InputJSON['meta'] = [
+    { name: 'id', type: 'UInt32' },
+    { name: 'name', type: 'String' },
+    { name: 'sku', type: 'Array(UInt32)' },
+  ]
+  await insertJSON('JSON', {
+    meta: [], // not required for JSON format input
+    data: [
+      { id: 17, name: 'foo', sku: [1, 2, 3] },
+      { id: 18, name: 'bar', sku: [4, 5, 6] },
+    ],
+  })
+  await insertJSON('JSONCompact', {
+    meta,
+    data: [
+      [19, 'foo', [1, 2, 3]],
+      [20, 'bar', [4, 5, 6]],
+    ],
+  })
+  await insertJSON('JSONColumnsWithMetadata', {
+    meta,
+    data: {
+      id: [21, 22],
+      name: ['foo', 'bar'],
+      sku: [
+        [1, 2, 3],
+        [4, 5, 6],
+      ],
+    },
+  })
+
+  // JSONObjectEachRow accepts Record<string, T> (alias: InputJSONObjectEachRow<T>).
+  // See https://clickhouse.com/docs/en/interfaces/formats#jsonobjecteachrow
+  await insertJSON('JSONObjectEachRow', {
+    row_1: { id: 23, name: 'foo', sku: [1, 2, 3] },
+    row_2: { id: 24, name: 'bar', sku: [4, 5, 6] },
+  })
+
+  // Print the inserted data - see that the IDs are matching.
+  await printInsertedData()
+  await client.close()
+
+  // Inserting data in different JSON formats
+  async function insertJSON<T = unknown>(
+    format: DataFormat,
+    values: ReadonlyArray<T> | InputJSON<T> | InputJSONObjectEachRow<T>
+  ) {
+    try {
+      await client.insert({
+        table: tableName,
+        format: format,
+        values,
+      })
+      console.log(`Successfully inserted data with format ${format}`)
+    } catch (err) {
+      console.error(`Failed to insert data with format ${format}, cause:`, err)
+      process.exit(1)
+    }
+  }
+
+  async function prepareTestTable() {
+    await client.command({
+      query: `
+        CREATE OR REPLACE TABLE ${tableName}
+        (id UInt32, name String, sku Array(UInt32))
+        ENGINE MergeTree()
+        ORDER BY (id)
+      `,
+    })
+  }
+
+  async function printInsertedData() {
+    const resultSet = await client.query({
+      query: `SELECT * FROM ${tableName} ORDER BY id ASC`,
+      format: 'JSONEachRow',
+    })
+    const data = await resultSet.json()
+    console.log('Inserted data:')
+    console.dir(data, { depth: null })
+  }
+})()

--- a/examples/insert_data_formats_overview.ts
+++ b/examples/insert_data_formats_overview.ts
@@ -23,6 +23,8 @@ import {
  *  - streaming from a CSV file - node/insert_file_stream_csv.ts
  *  - streaming from a Parquet file - node/insert_file_stream_parquet.ts
  *
+ * If some format is missing from the overview, you could help us by updating this example or submitting an issue.
+ *
  * See also:
  * - ClickHouse formats documentation - https://clickhouse.com/docs/en/interfaces/formats
  * - SELECT formats overview - select_data_formats_overview.ts
@@ -124,7 +126,7 @@ void (async () => {
   // Inserting data in different JSON formats
   async function insertJSON<T = unknown>(
     format: DataFormat,
-    values: ReadonlyArray<T> | InputJSON<T> | InputJSONObjectEachRow<T>
+    values: ReadonlyArray<T> | InputJSON<T> | InputJSONObjectEachRow<T>,
   ) {
     try {
       await client.insert({

--- a/examples/node/insert_file_stream_csv.ts
+++ b/examples/node/insert_file_stream_csv.ts
@@ -21,10 +21,11 @@ void (async () => {
 
   // contains data as 1,"foo","[1,2]"\n2,"bar","[3,4]"\n...
   const filename = Path.resolve(cwd(), './node/resources/data.csv')
+  const fileStream = Fs.createReadStream(filename)
 
   await client.insert({
     table: tableName,
-    values: Fs.createReadStream(filename),
+    values: fileStream,
     format: 'CSV',
   })
 

--- a/examples/node/insert_file_stream_ndjson.ts
+++ b/examples/node/insert_file_stream_ndjson.ts
@@ -22,12 +22,13 @@ void (async () => {
   // contains id as numbers in JSONCompactEachRow format ["0"]\n["0"]\n...
   // see also: NDJSON format
   const filename = Path.resolve(cwd(), './node/resources/data.ndjson')
+  const fileStream = Fs.createReadStream(filename).pipe(
+    split((row: string) => JSON.parse(row))
+  )
 
   await client.insert({
     table: tableName,
-    values: Fs.createReadStream(filename).pipe(
-      split((row: string) => JSON.parse(row))
-    ),
+    values: fileStream,
     format: 'JSONCompactEachRow',
   })
 

--- a/examples/node/insert_file_stream_parquet.ts
+++ b/examples/node/insert_file_stream_parquet.ts
@@ -20,6 +20,7 @@ void (async () => {
   })
 
   const filename = Path.resolve(cwd(), './node/resources/data.parquet')
+  const fileStream = Fs.createReadStream(filename)
 
   /*
 
@@ -37,7 +38,7 @@ void (async () => {
 
   await client.insert({
     table: tableName,
-    values: Fs.createReadStream(filename),
+    values: fileStream,
     format: 'Parquet',
   })
 

--- a/examples/package.json
+++ b/examples/package.json
@@ -12,7 +12,10 @@
   },
   "scripts": {},
   "dependencies": {
-    "@clickhouse/client": "latest",
+    "@clickhouse/client": "latest"
+  },
+  "devDependencies": {
+    "split2": "^4.2.0",
     "ts-node": "^10.9.1"
   }
 }

--- a/examples/select_data_formats_overview.ts
+++ b/examples/select_data_formats_overview.ts
@@ -1,0 +1,105 @@
+import { createClient } from '@clickhouse/client'
+import type { DataFormat } from '@clickhouse/client-common'
+
+/**
+ * An overview of all available formats for selecting your data.
+ * Run this example and see the shape of the parsed data for different formats.
+ *
+ * See also:
+ * - ClickHouse formats documentation - https://clickhouse.com/docs/en/interfaces/formats
+ * - INSERT formats overview - insert_data_formats_overview.ts
+ * - JSON data streaming example - select_streaming_json_each_row.ts
+ * - Streaming Parquet into a file - node/select_parquet_as_file.ts
+ */
+void (async () => {
+  const tableName = 'select_data_formats_overview'
+  const client = createClient()
+  await prepareTestData()
+
+  // These ClickHouse JSON formats can be streamed as well instead of loading the entire result into the app memory;
+  // See this example: node/select_streaming_json_each_row.ts
+  console.log('#### Streamable JSON formats:\n')
+  await selectJSON('JSONEachRow')
+  await selectJSON('JSONStringsEachRow')
+  await selectJSON('JSONCompactEachRow')
+  await selectJSON('JSONCompactStringsEachRow')
+  await selectJSON('JSONCompactEachRowWithNames')
+  await selectJSON('JSONCompactEachRowWithNamesAndTypes')
+  await selectJSON('JSONCompactStringsEachRowWithNames')
+  await selectJSON('JSONCompactStringsEachRowWithNamesAndTypes')
+
+  // These are single document ClickHouse JSON formats, which are not streamable
+  console.log('\n#### Single document JSON formats:\n')
+  await selectJSON('JSON')
+  await selectJSON('JSONStrings')
+  await selectJSON('JSONCompact')
+  await selectJSON('JSONCompactStrings')
+  await selectJSON('JSONColumnsWithMetadata')
+  await selectJSON('JSONObjectEachRow')
+
+  // These "raw" ClickHouse formats can be streamed as well instead of loading the entire result into the app memory;
+  // see node/select_streaming_text_line_by_line.ts
+  console.log('\n#### Raw formats:\n')
+  await selectText('CSV')
+  await selectText('CSVWithNames')
+  await selectText('CSVWithNamesAndTypes')
+  await selectText('TabSeparated')
+  await selectText('TabSeparatedRaw')
+  await selectText('TabSeparatedWithNames')
+  await selectText('TabSeparatedWithNamesAndTypes')
+  await selectText('CustomSeparated')
+  await selectText('CustomSeparatedWithNames')
+  await selectText('CustomSeparatedWithNamesAndTypes')
+
+  // Parquet can be streamed in and out, too.
+  // See node/select_parquet_as_file.ts, node/insert_file_stream_parquet.ts
+
+  await client.close()
+
+  // Selecting data in different JSON formats
+  async function selectJSON(format: DataFormat) {
+    const rows = await client.query({
+      query: `SELECT * FROM ${tableName} LIMIT 10`, // don't use FORMAT clause; specify the format separately
+      format: format,
+    })
+    const data = await rows.json() // get all the data at once
+    console.log(`Format: ${format}, parsed data:`)
+    console.dir(data, { depth: null }) // prints the nested arrays, too
+  }
+
+  // Selecting text data in different formats; `.json()` cannot be used here as it does not make sense.
+  async function selectText(format: DataFormat) {
+    const rows = await client.query({
+      query: `SELECT * FROM ${tableName} LIMIT 10`, // don't use FORMAT clause; specify the format separately
+      format: format,
+      clickhouse_settings: {
+        // This is for CustomSeparated format demo purposes.
+        // See also: https://clickhouse.com/docs/en/interfaces/formats#format-customseparated
+        format_custom_field_delimiter: ' | ',
+      },
+    })
+    const data = await rows.text() // get all the data at once
+    console.log(`Format: ${format}, text data:`)
+    console.log(data)
+  }
+
+  async function prepareTestData() {
+    await client.command({
+      query: `
+        CREATE OR REPLACE TABLE ${tableName}
+        (id UInt32, name String, sku Array(UInt32))
+        ENGINE MergeTree()
+        ORDER BY (id)
+      `,
+    })
+    // See also: INSERT formats overview - insert_data_formats_overview.ts
+    await client.insert({
+      table: tableName,
+      values: [
+        { id: 42, name: 'foo', sku: [1, 2, 3] },
+        { id: 43, name: 'bar', sku: [4, 5, 6] },
+      ],
+      format: 'JSONEachRow',
+    })
+  }
+})()

--- a/examples/select_data_formats_overview.ts
+++ b/examples/select_data_formats_overview.ts
@@ -7,6 +7,8 @@ import type { DataFormat } from '@clickhouse/client-common'
  *
  * An example of console output is available here: https://gist.github.com/slvrtrn/3ad657c4e236e089a234d79b87600f76
  *
+ * If some format is missing from the overview, you could help us by updating this example or submitting an issue.
+ *
  * See also:
  * - ClickHouse formats documentation - https://clickhouse.com/docs/en/interfaces/formats
  * - INSERT formats overview - insert_data_formats_overview.ts

--- a/examples/select_data_formats_overview.ts
+++ b/examples/select_data_formats_overview.ts
@@ -5,6 +5,8 @@ import type { DataFormat } from '@clickhouse/client-common'
  * An overview of all available formats for selecting your data.
  * Run this example and see the shape of the parsed data for different formats.
  *
+ * An example of console output is available here: https://gist.github.com/slvrtrn/3ad657c4e236e089a234d79b87600f76
+ *
  * See also:
  * - ClickHouse formats documentation - https://clickhouse.com/docs/en/interfaces/formats
  * - INSERT formats overview - insert_data_formats_overview.ts


### PR DESCRIPTION
More examples: select and insert formats overview. 
I am not sure why we did not have this from the beginning, as these overviews are incredibly useful as a quick reference.