### PR TITLE
Update error message assertion in tests

### DIFF
--- a/.docker/clickhouse/single_node_tls/Dockerfile
+++ b/.docker/clickhouse/single_node_tls/Dockerfile
@@ -1,4 +1,4 @@
-FROM clickhouse/clickhouse-server:24.2-alpine
+FROM clickhouse/clickhouse-server:24.3-alpine
 COPY .docker/clickhouse/single_node_tls/certificates /etc/clickhouse-server/certs
 RUN chown clickhouse:clickhouse -R /etc/clickhouse-server/certs \
     && chmod 600 /etc/clickhouse-server/certs/* \

--- a/docker-compose.cluster.yml
+++ b/docker-compose.cluster.yml
@@ -2,7 +2,7 @@ version: '2.3'
 
 services:
   clickhouse1:
-    image: 'clickhouse/clickhouse-server:${CLICKHOUSE_VERSION-24.2-alpine}'
+    image: 'clickhouse/clickhouse-server:${CLICKHOUSE_VERSION-24.3-alpine}'
     ulimits:
       nofile:
         soft: 262144
@@ -19,7 +19,7 @@ services:
       - './.docker/clickhouse/users.xml:/etc/clickhouse-server/users.xml'
 
   clickhouse2:
-    image: 'clickhouse/clickhouse-server:${CLICKHOUSE_VERSION-24.2-alpine}'
+    image: 'clickhouse/clickhouse-server:${CLICKHOUSE_VERSION-24.3-alpine}'
     ulimits:
       nofile:
         soft: 262144

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.8'
 services:
   clickhouse:
-    image: 'clickhouse/clickhouse-server:${CLICKHOUSE_VERSION-24.2-alpine}'
+    image: 'clickhouse/clickhouse-server:${CLICKHOUSE_VERSION-24.3-alpine}'
     container_name: 'clickhouse-js-clickhouse-server'
     ports:
       - '8123:8123'

--- a/packages/client-node/__tests__/integration/node_streaming_e2e.test.ts
+++ b/packages/client-node/__tests__/integration/node_streaming_e2e.test.ts
@@ -113,7 +113,6 @@ describe('[Node.js] streaming e2e', () => {
       'Schema<{ 0: id: Uint64, 1: name: Utf8, 2: sku: List<Uint8> }>'
     )
     const actualParquetData: unknown[] = []
-    const textDecoder = new TextDecoder()
     table.toArray().map((v) => {
       const row: Record<string, unknown> = {}
       row['id'] = v.id


### PR DESCRIPTION
## Summary

The `UNKNOWN_IDENTIFIER` error message is slightly different now as of 24.3. 
Bumped ClickHouse versions in Docker as well.

## Checklist
- [x] Unit and integration tests covering the common scenarios were added