### PR TITLE
Improved performance when decoding the entire set of rows with streamable JSON formats

### DIFF
--- a/benchmarks/common/handlers.ts
+++ b/benchmarks/common/handlers.ts
@@ -1,0 +1,9 @@
+export function attachExceptionHandlers() {
+  process.on('uncaughtException', (err) => logAndQuit(err))
+  process.on('unhandledRejection', (err) => logAndQuit(err))
+
+  function logAndQuit(err: unknown) {
+    console.error(err)
+    process.exit(1)
+  }
+}

--- a/benchmarks/common/index.ts
+++ b/benchmarks/common/index.ts
@@ -1,0 +1,1 @@
+export * from './handlers'

--- a/benchmarks/formats/json.ts
+++ b/benchmarks/formats/json.ts
@@ -1,0 +1,110 @@
+import { createClient } from '@clickhouse/client'
+import { attachExceptionHandlers } from '../common'
+
+/*
+Large strings table definition:
+
+  CREATE TABLE large_strings
+  (
+      `id` UInt32,
+      `s1` String,
+      `s2` String,
+      `s3` String
+  )
+  ENGINE = MergeTree
+  ORDER BY id;
+
+  INSERT INTO large_strings
+  SELECT number + 1,
+         randomPrintableASCII(randUniform(500, 2500)) AS s1,
+         randomPrintableASCII(randUniform(500, 2500)) AS s2,
+         randomPrintableASCII(randUniform(500, 2500)) AS s3
+  FROM numbers(100000);
+*/
+
+const WarmupIterations = 3
+const BenchmarkIterations = 10
+
+const largeStringsQuery = `SELECT * FROM large_strings ORDER BY id ASC LIMIT 100000`
+const cellTowersQuery = `SELECT * FROM cell_towers ORDER BY (radio, mcc, net, created) ASC LIMIT 500000`
+const queries = [largeStringsQuery, cellTowersQuery]
+
+const formats = ['JSON', 'JSONEachRow', 'JSONObjectEachRow'] as const
+
+void (async () => {
+  const client = createClient({
+    url: 'http://localhost:8123',
+    compression: {
+      request: false,
+      response: false,
+    },
+  })
+
+  type TotalPerQuery = Record<string, number>
+  const results: Record<(typeof formats)[number], TotalPerQuery> = {
+    JSON: {},
+    JSONEachRow: {},
+    JSONObjectEachRow: {},
+  }
+
+  async function benchmarkJSON(
+    format: (typeof formats)[number],
+    query: string,
+    keepResults: boolean,
+  ) {
+    const start = +new Date()
+    const rs = await client.query({
+      query,
+      format,
+    })
+    await rs.json() // discard the result
+    const elapsed = +new Date() - start
+    if (keepResults) {
+      const current = results[format][query] ?? 0
+      results[format][query] = current + elapsed
+    }
+    logResult(format, query, elapsed)
+  }
+
+  attachExceptionHandlers()
+  process.on('SIGINT', closeAndExit)
+  process.on('SIGINT', closeAndExit)
+
+  console.log('Warmup')
+  for (let i = 0; i < WarmupIterations; i++) {
+    await runQueries(false)
+  }
+  console.log('Benchmarking')
+  for (let i = 0; i < BenchmarkIterations; i++) {
+    await runQueries(true)
+  }
+  console.log('Results:', results)
+  console.log('Average results:')
+  for (const format of formats) {
+    for (const query of queries) {
+      const avg = Math.floor(results[format][query] / BenchmarkIterations)
+      logResult(format, query, avg)
+    }
+  }
+  await closeAndExit()
+
+  function logResult(format: string, query: string, elapsed: number) {
+    const elapsedStr = elapsed.toString(10) + ' ms'
+    console.log(
+      `[${elapsedStr.padEnd(10)}][${format.padEnd(18)}][${query.padEnd(80)}]`,
+    )
+  }
+
+  async function runQueries(keepResults: boolean) {
+    for (const query of queries) {
+      for (const format of formats) {
+        await benchmarkJSON(format, query, keepResults)
+      }
+    }
+  }
+
+  async function closeAndExit() {
+    await client.close()
+    process.exit(0)
+  }
+})()

--- a/benchmarks/formats/json.ts
+++ b/benchmarks/formats/json.ts
@@ -25,11 +25,11 @@ Large strings table definition:
 const WarmupIterations = 3
 const BenchmarkIterations = 10
 
-const largeStringsQuery = `SELECT * FROM large_strings ORDER BY id ASC LIMIT 100000`
-const cellTowersQuery = `SELECT * FROM cell_towers ORDER BY (radio, mcc, net, created) ASC LIMIT 500000`
+const largeStringsQuery = `SELECT * FROM large_strings ORDER BY id ASC LIMIT 50000`
+const cellTowersQuery = `SELECT * FROM cell_towers ORDER BY (radio, mcc, net, created) ASC LIMIT 200000`
 const queries = [largeStringsQuery, cellTowersQuery]
 
-const formats = ['JSON', 'JSONEachRow', 'JSONObjectEachRow'] as const
+const formats = ['JSONEachRow'] as const
 
 void (async () => {
   const client = createClient({
@@ -42,9 +42,7 @@ void (async () => {
 
   type TotalPerQuery = Record<string, number>
   const results: Record<(typeof formats)[number], TotalPerQuery> = {
-    JSON: {},
     JSONEachRow: {},
-    JSONObjectEachRow: {},
   }
 
   async function benchmarkJSON(

--- a/benchmarks/leaks/memory_leak_arrays.ts
+++ b/benchmarks/leaks/memory_leak_arrays.ts
@@ -1,7 +1,8 @@
-import { v4 as uuid_v4 } from 'uuid'
+import { createClient } from '@clickhouse/client'
 import { randomInt } from 'crypto'
+import { v4 as uuid_v4 } from 'uuid'
+import { attachExceptionHandlers } from '../common'
 import {
-  attachExceptionHandlers,
   getMemoryUsageInMegabytes,
   logFinalMemoryUsage,
   logMemoryUsage,
@@ -9,7 +10,6 @@ import {
   randomArray,
   randomStr,
 } from './shared'
-import { createClient } from '@clickhouse/client'
 
 const program = async () => {
   const client = createClient({})

--- a/benchmarks/leaks/memory_leak_brown.ts
+++ b/benchmarks/leaks/memory_leak_brown.ts
@@ -1,14 +1,14 @@
-import { v4 as uuid_v4 } from 'uuid'
-import Path from 'path'
+import { createClient } from '@clickhouse/client'
 import Fs from 'fs'
+import Path from 'path'
+import { v4 as uuid_v4 } from 'uuid'
+import { attachExceptionHandlers } from '../common'
 import {
-  attachExceptionHandlers,
   getMemoryUsageInMegabytes,
   logFinalMemoryUsage,
   logMemoryUsage,
   logMemoryUsageDiff,
 } from './shared'
-import { createClient } from '@clickhouse/client'
 
 const program = async () => {
   const client = createClient({})

--- a/benchmarks/leaks/memory_leak_random_integers.ts
+++ b/benchmarks/leaks/memory_leak_random_integers.ts
@@ -1,9 +1,9 @@
-import Stream from 'stream'
 import { createClient } from '@clickhouse/client'
-import { v4 as uuid_v4 } from 'uuid'
 import { randomInt } from 'crypto'
+import Stream from 'stream'
+import { v4 as uuid_v4 } from 'uuid'
+import { attachExceptionHandlers } from '../common'
 import {
-  attachExceptionHandlers,
   getMemoryUsageInMegabytes,
   logFinalMemoryUsage,
   logMemoryUsage,

--- a/benchmarks/leaks/shared.ts
+++ b/benchmarks/leaks/shared.ts
@@ -1,15 +1,5 @@
 import { memoryUsage } from 'process'
 
-export function attachExceptionHandlers() {
-  process.on('uncaughtException', (err) => logAndQuit(err))
-  process.on('unhandledRejection', (err) => logAndQuit(err))
-
-  function logAndQuit(err: unknown) {
-    console.error(err)
-    process.exit(1)
-  }
-}
-
 export interface MemoryUsage {
   rss: number
   heapTotal: number

--- a/benchmarks/tsconfig.json
+++ b/benchmarks/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "extends": "../tsconfig.json",
-  "include": ["leaks/**/*.ts"],
+  "include": ["dev/**/*.ts", "formats/**/*.ts", "leaks/**/*.ts"],
   "compilerOptions": {
     "noUnusedLocals": false,
     "noUnusedParameters": false,

--- a/packages/client-common/src/data_formatter/formatter.ts
+++ b/packages/client-common/src/data_formatter/formatter.ts
@@ -107,27 +107,6 @@ export function validateStreamFormat(
 }
 
 /**
- * Decodes a string in a ClickHouse format into a plain JavaScript object or an array of objects.
- * @param text a string in a ClickHouse data format
- * @param format One of the supported formats: https://clickhouse.com/docs/en/interfaces/formats/
- */
-export function decode(text: string, format: DataFormat): any {
-  if (isNotStreamableJSONFamily(format)) {
-    return JSON.parse(text)
-  }
-  if (isStreamableJSONFamily(format)) {
-    return text
-      .split('\n')
-      .filter(Boolean)
-      .map((l) => decode(l, 'JSON'))
-  }
-  if (isSupportedRawFormat(format)) {
-    throw new Error(`Cannot decode ${format} to JSON`)
-  }
-  throw new Error(`The client does not support [${format}] format decoding.`)
-}
-
-/**
  * Encodes a single row of values into a string in a JSON format acceptable by ClickHouse.
  * @param value a single value to encode.
  * @param format One of the supported JSON formats: https://clickhouse.com/docs/en/interfaces/formats/

--- a/packages/client-common/src/index.ts
+++ b/packages/client-common/src/index.ts
@@ -44,12 +44,22 @@ export {
 } from './settings'
 
 /** For implementations usage only - should not be re-exported */
+export type {
+  RawDataFormat,
+  JSONDataFormat,
+  StreamableDataFormat,
+  StreamableJSONDataFormat,
+  SingleDocumentJSONFormat,
+} from './data_formatter'
 export {
+  formatQuerySettings,
+  formatQueryParams,
   encodeJSON,
   isSupportedRawFormat,
+  isStreamableJSONFamily,
+  isNotStreamableJSONFamily,
   decode,
   validateStreamFormat,
-  StreamableDataFormat,
 } from './data_formatter'
 export {
   type ValuesEncoder,
@@ -84,11 +94,5 @@ export type {
   ConnPingResult,
   ConnOperation,
 } from './connection'
-export {
-  type RawDataFormat,
-  type JSONDataFormat,
-  formatQuerySettings,
-  formatQueryParams,
-} from './data_formatter'
 export type { QueryParamsWithFormat } from './client'
 export type { IsSame } from './ts_utils'

--- a/packages/client-common/src/index.ts
+++ b/packages/client-common/src/index.ts
@@ -58,7 +58,6 @@ export {
   isSupportedRawFormat,
   isStreamableJSONFamily,
   isNotStreamableJSONFamily,
-  decode,
   validateStreamFormat,
 } from './data_formatter'
 export {

--- a/packages/client-node/src/result_set.ts
+++ b/packages/client-node/src/result_set.ts
@@ -1,11 +1,13 @@
-import {
+import type {
   BaseResultSet,
   DataFormat,
-  isNotStreamableJSONFamily,
-  isStreamableJSONFamily,
   ResultJSONType,
   ResultStream,
   Row,
+} from '@clickhouse/client-common'
+import {
+  isNotStreamableJSONFamily,
+  isStreamableJSONFamily,
   validateStreamFormat,
 } from '@clickhouse/client-common'
 import { Buffer } from 'buffer'
@@ -64,22 +66,22 @@ export class ResultSet<Format extends DataFormat | unknown>
       await new Promise((resolve, reject) => {
         const stream = this.stream<T>()
         stream.on('data', (rows: Row[]) => {
-          rows.forEach((row) => {
+          for (const row of rows) {
             result.push(row.json())
-          })
+          }
         })
         stream.on('end', resolve)
         stream.on('error', reject)
       })
       return result as any
     }
-    // JSON, etc.
+    // JSON, JSONObjectEachRow, etc.
     if (isNotStreamableJSONFamily(this.format as DataFormat)) {
       const text = await getAsText(this._stream)
       return JSON.parse(text)
     }
     // should not be called for CSV, etc.
-    throw new Error(`Cannot decode ${this.format} to JSON`)
+    throw new Error(`Cannot decode ${this.format} as JSON`)
   }
 
   /** See {@link BaseResultSet.stream}. */

--- a/packages/client-web/__tests__/integration/web_select_streaming.test.ts
+++ b/packages/client-web/__tests__/integration/web_select_streaming.test.ts
@@ -40,9 +40,9 @@ describe('[Web] SELECT streaming', () => {
     it('should consume a text response only once', async () => {
       const rs = await client.query({
         query: 'SELECT * FROM system.numbers LIMIT 1',
-        format: 'TabSeparated',
+        format: 'JSONEachRow',
       })
-      expect(await rs.text()).toEqual('0\n')
+      expect(await rs.text()).toEqual('{"number":"0"}\n')
       // wrap in a func to avoid changing inner "this"
       await assertAlreadyConsumed$(() => rs.json())
       await assertAlreadyConsumed$(() => rs.text())
@@ -52,10 +52,10 @@ describe('[Web] SELECT streaming', () => {
     it('should consume a stream response only once', async () => {
       const rs = await client.query({
         query: 'SELECT * FROM system.numbers LIMIT 1',
-        format: 'TabSeparated',
+        format: 'JSONEachRow',
       })
       const result = await rowsText(rs.stream())
-      expect(result).toEqual(['0'])
+      expect(result).toEqual(['{"number":"0"}'])
       // wrap in a func to avoid changing inner "this"
       await assertAlreadyConsumed$(() => rs.json())
       await assertAlreadyConsumed$(() => rs.text())

--- a/packages/client-web/src/result_set.ts
+++ b/packages/client-web/src/result_set.ts
@@ -5,7 +5,11 @@ import type {
   ResultStream,
   Row,
 } from '@clickhouse/client-common'
-import { decode, validateStreamFormat } from '@clickhouse/client-common'
+import {
+  isNotStreamableJSONFamily,
+  isStreamableJSONFamily,
+} from '@clickhouse/client-common'
+import { validateStreamFormat } from '@clickhouse/client-common'
 import { getAsText } from './utils'
 
 export class ResultSet<Format extends DataFormat | unknown>
@@ -26,8 +30,30 @@ export class ResultSet<Format extends DataFormat | unknown>
 
   /** See {@link BaseResultSet.json} */
   async json<T>(): Promise<ResultJSONType<T, Format>> {
-    const text = await this.text()
-    return decode(text, this.format as DataFormat)
+    this.markAsConsumed()
+    // JSONEachRow, etc.
+    if (isStreamableJSONFamily(this.format as DataFormat)) {
+      const result: T[] = []
+      const reader = this.stream<T>().getReader()
+      // eslint-disable-next-line no-constant-condition
+      while (true) {
+        const { done, value } = await reader.read()
+        if (done) {
+          break
+        }
+        for (const row of value) {
+          result.push(row.json())
+        }
+      }
+      return result as any
+    }
+    // JSON, JSONObjectEachRow, etc.
+    if (isNotStreamableJSONFamily(this.format as DataFormat)) {
+      const text = await getAsText(this._stream)
+      return JSON.parse(text)
+    }
+    // should not be called for CSV, etc.
+    throw new Error(`Cannot decode ${this.format} as JSON`)
   }
 
   /** See {@link BaseResultSet.stream} */
@@ -56,7 +82,7 @@ export class ResultSet<Format extends DataFormat | unknown>
             rows.push({
               text,
               json<T>(): T {
-                return decode(text, 'JSON')
+                return JSON.parse(text)
               },
             })
           } else {

--- a/packages/client-web/src/result_set.ts
+++ b/packages/client-web/src/result_set.ts
@@ -30,7 +30,6 @@ export class ResultSet<Format extends DataFormat | unknown>
 
   /** See {@link BaseResultSet.json} */
   async json<T>(): Promise<ResultJSONType<T, Format>> {
-    this.markAsConsumed()
     // JSONEachRow, etc.
     if (isStreamableJSONFamily(this.format as DataFormat)) {
       const result: T[] = []


### PR DESCRIPTION
## Summary

* Improved performance when decoding the entire set of rows with _streamable_ JSON formats (such as `JSONEachRow` or `JSONCompactEachRow`) by calling the `ResultSet.json()` method. Depending on the dataset, it's between 10-15% (like [cell_towers](https://clickhouse.com/docs/en/getting-started/example-datasets/cell-towers)) and 40% (with large rows and very long strings) less execution time. NB: The actual streaming performance when consuming the `ResultSet.stream()` (which was fast) hasn't changed. Only the `ResultSet.json()` method used a suboptimal stream processing in some instances, and now `ResultSet.json()` just consumes the same stream transformer provided by the `ResultSet.stream()` method.

  Before:
  ```
  [1277 ms   ][JSONEachRow       ][SELECT * FROM large_strings ORDER BY id ASC LIMIT 100000                        ]
  [668 ms    ][JSONEachRow       ][SELECT * FROM cell_towers ORDER BY (radio, mcc, net, created) ASC LIMIT 500000  ]
  ```
  After:
  ```
  [737 ms    ][JSONEachRow       ][SELECT * FROM large_strings ORDER BY id ASC LIMIT 100000                        ]
  [578 ms    ][JSONEachRow       ][SELECT * FROM cell_towers ORDER BY (radio, mcc, net, created) ASC LIMIT 500000  ]
  ```

* Removed the outdated `decode` function.
* Updated exported types and doc entries for DataFormat.
* Fixed weird flakiness in expect-type assertions
