### PR TITLE
Drain the response stream in the command method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Bug fixes
 
-- The `command` method now drains the response stream properly, as in the previous implementation it could cause the Keep-Alive socket to close after each request.
+- The `command` method now drains the response stream properly, as the previous implementation could cause the Keep-Alive socket to close after each request.
 
 # 1.0.1 (Common, Node.js, Web)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Bug fixes
 
-- `command` method now drains the response stream properly, as the previous implementation it could cause the Keep-Alive socket to close after each request.
+- The `command` method now drains the response stream properly, as in the previous implementation it could cause the Keep-Alive socket to close after each request.
 
 # 1.0.1 (Common, Node.js, Web)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 1.0.2 (Common, Node.js, Web)
+
+## Bug fixes
+
+- `command` method now drains the response stream properly, as the previous implementation it could cause the Keep-Alive socket to close after each request.
+
 # 1.0.1 (Common, Node.js, Web)
 
 ## Bug fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
-# 1.0.2 (Common, Node.js, Web)
+# 1.0.2 (Common, Node.js)
 
 ## Bug fixes
 
-- The `command` method now drains the response stream properly, as the previous implementation could cause the Keep-Alive socket to close after each request.
+- (Node.js only) The `command` method now drains the response stream properly, as the previous implementation could cause the Keep-Alive socket to close after each request.
 
 # 1.0.1 (Common, Node.js, Web)
 

--- a/examples/package.json
+++ b/examples/package.json
@@ -12,7 +12,7 @@
   },
   "scripts": {},
   "dependencies": {
-    "@clickhouse/client": "latest"
+    "@clickhouse/client": "1.0.1"
   },
   "devDependencies": {
     "set-interval-async": "^3.0.3",

--- a/examples/package.json
+++ b/examples/package.json
@@ -12,7 +12,7 @@
   },
   "scripts": {},
   "dependencies": {
-    "@clickhouse/client": "1.0.1"
+    "@clickhouse/client": "latest"
   },
   "devDependencies": {
     "set-interval-async": "^3.0.3",

--- a/packages/client-common/src/config.ts
+++ b/packages/client-common/src/config.ts
@@ -113,8 +113,6 @@ export interface ValuesEncoder<Stream> {
   ): string | Stream
 }
 
-export type CloseStream<Stream> = (stream: Stream) => Promise<void>
-
 /**
  * An implementation might have extra config parameters that we can parse from the connection URL.
  * These are supposed to be processed after we finish parsing the base configuration.
@@ -141,7 +139,6 @@ export interface ImplementationDetails<Stream> {
     make_connection: MakeConnection<Stream>
     make_result_set: MakeResultSet<Stream>
     values_encoder: ValuesEncoder<Stream>
-    close_stream: CloseStream<Stream>
     handle_specific_url_params?: HandleImplSpecificURLParams
   }
 }

--- a/packages/client-common/src/connection.ts
+++ b/packages/client-common/src/connection.ts
@@ -47,6 +47,7 @@ export interface ConnQueryResult<Stream> extends ConnBaseResult {
 export type ConnInsertResult = ConnBaseResult & WithClickHouseSummary
 export type ConnExecResult<Stream> = ConnQueryResult<Stream> &
   WithClickHouseSummary
+export type ConnCommandResult = ConnBaseResult & WithClickHouseSummary
 
 export type ConnPingResult =
   | {
@@ -54,12 +55,13 @@ export type ConnPingResult =
     }
   | { success: false; error: Error }
 
-export type ConnOperation = 'Ping' | 'Query' | 'Insert' | 'Exec'
+export type ConnOperation = 'Ping' | 'Query' | 'Insert' | 'Exec' | 'Command'
 
 export interface Connection<Stream> {
   ping(): Promise<ConnPingResult>
   close(): Promise<void>
   query(params: ConnBaseQueryParams): Promise<ConnQueryResult<Stream>>
-  exec(params: ConnBaseQueryParams): Promise<ConnExecResult<Stream>>
   insert(params: ConnInsertParams<Stream>): Promise<ConnInsertResult>
+  exec(params: ConnBaseQueryParams): Promise<ConnExecResult<Stream>>
+  command(params: ConnBaseQueryParams): Promise<ConnCommandResult>
 }

--- a/packages/client-common/src/index.ts
+++ b/packages/client-common/src/index.ts
@@ -91,6 +91,7 @@ export type {
   ConnBaseResult,
   ConnInsertParams,
   ConnPingResult,
+  ConnCommandResult,
   ConnOperation,
 } from './connection'
 export type { QueryParamsWithFormat } from './client'

--- a/packages/client-node/src/config.ts
+++ b/packages/client-node/src/config.ts
@@ -103,7 +103,4 @@ export const NodeConfigImpl: Required<
     format: DataFormat,
     query_id: string,
   ) => new ResultSet(stream, format, query_id)) as any,
-  close_stream: async (stream) => {
-    stream.destroy()
-  },
 }

--- a/packages/client-node/src/connection/node_base_connection.ts
+++ b/packages/client-node/src/connection/node_base_connection.ts
@@ -1,6 +1,7 @@
 import type {
   ClickHouseSummary,
   ConnBaseQueryParams,
+  ConnCommandResult,
   Connection,
   ConnectionParams,
   ConnExecResult,
@@ -27,7 +28,6 @@ import Zlib from 'zlib'
 import { getAsText, getUserAgent, isStream } from '../utils'
 import { decompressResponse, isDecompressionError } from './compression'
 import { drainStream } from './stream'
-import type { ConnCommandResult } from '@clickhouse/client-common'
 
 export type NodeConnectionParams = ConnectionParams & {
   tls?: TLSParams

--- a/packages/client-node/src/connection/node_base_connection.ts
+++ b/packages/client-node/src/connection/node_base_connection.ts
@@ -27,6 +27,7 @@ import Zlib from 'zlib'
 import { getAsText, getUserAgent, isStream } from '../utils'
 import { decompressResponse, isDecompressionError } from './compression'
 import { drainStream } from './stream'
+import type { ConnCommandResult } from '@clickhouse/client-common/src/connection'
 
 export type NodeConnectionParams = ConnectionParams & {
   tls?: TLSParams
@@ -80,6 +81,156 @@ export abstract class NodeBaseConnection
     )
   }
 
+  async ping(): Promise<ConnPingResult> {
+    const abortController = new AbortController()
+    try {
+      const { stream } = await this.request(
+        {
+          method: 'GET',
+          url: transformUrl({ url: this.params.url, pathname: '/ping' }),
+          abort_signal: abortController.signal,
+        },
+        'Ping',
+      )
+      await drainStream(stream)
+      return { success: true }
+    } catch (error) {
+      // it is used to ensure that the outgoing request is terminated,
+      // and we don't get an unhandled error propagation later
+      abortController.abort('Ping failed')
+      // not an error, as this might be semi-expected
+      this.logger.warn({
+        message: this.httpRequestErrorMessage('Ping'),
+        err: error as Error,
+      })
+      return {
+        success: false,
+        error: error as Error, // should NOT be propagated to the user
+      }
+    }
+  }
+
+  async query(
+    params: ConnBaseQueryParams,
+  ): Promise<ConnQueryResult<Stream.Readable>> {
+    const query_id = this.getQueryId(params.query_id)
+    const clickhouse_settings = withHttpSettings(
+      params.clickhouse_settings,
+      this.params.compression.decompress_response,
+    )
+    const searchParams = toSearchParams({
+      database: this.params.database,
+      clickhouse_settings,
+      query_params: params.query_params,
+      session_id: params.session_id,
+      query_id,
+    })
+    const decompressResponse = clickhouse_settings.enable_http_compression === 1
+    const { controller, controllerCleanup } = this.getAbortController(params)
+    try {
+      const { stream } = await this.request(
+        {
+          method: 'POST',
+          url: transformUrl({ url: this.params.url, searchParams }),
+          body: params.query,
+          abort_signal: controller.signal,
+          decompress_response: decompressResponse,
+        },
+        'Query',
+      )
+      return {
+        stream,
+        query_id,
+      }
+    } catch (err) {
+      controller.abort('Query HTTP request failed')
+      this.logRequestError({
+        op: 'Query',
+        query_id: query_id,
+        query_params: params,
+        search_params: searchParams,
+        err: err as Error,
+        extra_args: {
+          decompress_response: decompressResponse,
+          clickhouse_settings,
+        },
+      })
+      throw err // should be propagated to the user
+    } finally {
+      controllerCleanup()
+    }
+  }
+
+  async insert(
+    params: ConnInsertParams<Stream.Readable>,
+  ): Promise<ConnInsertResult> {
+    const query_id = this.getQueryId(params.query_id)
+    const searchParams = toSearchParams({
+      database: this.params.database,
+      clickhouse_settings: params.clickhouse_settings,
+      query_params: params.query_params,
+      query: params.query,
+      session_id: params.session_id,
+      query_id,
+    })
+    const { controller, controllerCleanup } = this.getAbortController(params)
+    try {
+      const { stream, summary } = await this.request(
+        {
+          method: 'POST',
+          url: transformUrl({ url: this.params.url, searchParams }),
+          body: params.values,
+          abort_signal: controller.signal,
+          compress_request: this.params.compression.compress_request,
+          parse_summary: true,
+        },
+        'Insert',
+      )
+      await drainStream(stream)
+      return { query_id, summary }
+    } catch (err) {
+      controller.abort('Insert HTTP request failed')
+      this.logRequestError({
+        op: 'Insert',
+        query_id: query_id,
+        query_params: params,
+        search_params: searchParams,
+        err: err as Error,
+        extra_args: {
+          clickhouse_settings: params.clickhouse_settings ?? {},
+        },
+      })
+      throw err // should be propagated to the user
+    } finally {
+      controllerCleanup()
+    }
+  }
+
+  async exec(
+    params: ConnBaseQueryParams,
+  ): Promise<ConnExecResult<Stream.Readable>> {
+    return this.runExec({
+      ...params,
+      op: 'Exec',
+    })
+  }
+
+  async command(params: ConnBaseQueryParams): Promise<ConnCommandResult> {
+    const { stream, query_id, summary } = await this.runExec({
+      ...params,
+      op: 'Command',
+    })
+    // ignore the response stream and release the socket immediately
+    await drainStream(stream)
+    return { query_id, summary }
+  }
+
+  async close(): Promise<void> {
+    if (this.agent !== undefined && this.agent.destroy !== undefined) {
+      this.agent.destroy()
+    }
+  }
+
   protected buildDefaultHeaders(
     username: string,
     password: string,
@@ -99,6 +250,145 @@ export abstract class NodeBaseConnection
   protected abstract createClientRequest(
     params: RequestParams,
   ): Http.ClientRequest
+
+  private getQueryId(query_id: string | undefined): string {
+    return query_id || crypto.randomUUID()
+  }
+
+  // a wrapper over the user's Signal to terminate the failed requests
+  private getAbortController(params: ConnBaseQueryParams): {
+    controller: AbortController
+    controllerCleanup: () => void
+  } {
+    const controller = new AbortController()
+    function onAbort() {
+      controller.abort()
+    }
+    params.abort_signal?.addEventListener('abort', onAbort)
+    return {
+      controller,
+      controllerCleanup: () => {
+        params.abort_signal?.removeEventListener('abort', onAbort)
+      },
+    }
+  }
+
+  private logResponse(
+    op: ConnOperation,
+    request: Http.ClientRequest,
+    params: RequestParams,
+    response: Http.IncomingMessage,
+    startTimestamp: number,
+  ) {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { authorization, host, ...headers } = request.getHeaders()
+    const duration = Date.now() - startTimestamp
+    this.params.log_writer.debug({
+      module: 'HTTP Adapter',
+      message: `${op}: got a response from ClickHouse`,
+      args: {
+        request_method: params.method,
+        request_path: params.url.pathname,
+        request_params: params.url.search,
+        request_headers: headers,
+        response_status: response.statusCode,
+        response_headers: response.headers,
+        response_time_ms: duration,
+      },
+    })
+  }
+
+  private logRequestError({
+    op,
+    err,
+    query_id,
+    query_params,
+    search_params,
+    extra_args,
+  }: LogRequestErrorParams) {
+    this.logger.error({
+      message: this.httpRequestErrorMessage(op),
+      err: err as Error,
+      args: {
+        query: query_params.query,
+        search_params: search_params?.toString() ?? '',
+        with_abort_signal: query_params.abort_signal !== undefined,
+        session_id: query_params.session_id,
+        query_id: query_id,
+        ...extra_args,
+      },
+    })
+  }
+
+  private httpRequestErrorMessage(op: ConnOperation): string {
+    return `${op}: HTTP request error.`
+  }
+
+  private parseSummary(
+    op: ConnOperation,
+    response: Http.IncomingMessage,
+  ): ClickHouseSummary | undefined {
+    const summaryHeader = response.headers['x-clickhouse-summary']
+    if (typeof summaryHeader === 'string') {
+      try {
+        return JSON.parse(summaryHeader)
+      } catch (err) {
+        this.logger.error({
+          message: `${op}: failed to parse X-ClickHouse-Summary header.`,
+          args: {
+            'X-ClickHouse-Summary': summaryHeader,
+          },
+          err: err as Error,
+        })
+      }
+    }
+  }
+
+  private async runExec(
+    params: RunExecParams,
+  ): Promise<ConnExecResult<Stream.Readable>> {
+    const query_id = this.getQueryId(params.query_id)
+    const searchParams = toSearchParams({
+      database: this.params.database,
+      clickhouse_settings: params.clickhouse_settings,
+      query_params: params.query_params,
+      session_id: params.session_id,
+      query_id,
+    })
+    const { controller, controllerCleanup } = this.getAbortController(params)
+    try {
+      const { stream, summary } = await this.request(
+        {
+          method: 'POST',
+          url: transformUrl({ url: this.params.url, searchParams }),
+          body: params.query,
+          abort_signal: controller.signal,
+          parse_summary: true,
+        },
+        params.op,
+      )
+      return {
+        stream,
+        query_id,
+        summary,
+      }
+    } catch (err) {
+      controller.abort(`${params.op} HTTP request failed`)
+      this.logRequestError({
+        op: params.op,
+        query_id: query_id,
+        query_params: params,
+        search_params: searchParams,
+        err: err as Error,
+        extra_args: {
+          clickhouse_settings: params.clickhouse_settings ?? {},
+        },
+      })
+      throw err // should be propagated to the user
+    } finally {
+      controllerCleanup()
+    }
+  }
 
   private async request(
     params: RequestParams,
@@ -277,276 +567,6 @@ export abstract class NodeBaseConnection
       if (!params.body) return request.end()
     })
   }
-
-  async ping(): Promise<ConnPingResult> {
-    const abortController = new AbortController()
-    try {
-      const { stream } = await this.request(
-        {
-          method: 'GET',
-          url: transformUrl({ url: this.params.url, pathname: '/ping' }),
-          abort_signal: abortController.signal,
-        },
-        'Ping',
-      )
-      await drainStream(stream)
-      return { success: true }
-    } catch (error) {
-      // it is used to ensure that the outgoing request is terminated,
-      // and we don't get an unhandled error propagation later
-      abortController.abort('Ping failed')
-      // not an error, as this might be semi-expected
-      this.logger.warn({
-        message: this.httpRequestErrorMessage('Ping'),
-        err: error as Error,
-      })
-      return {
-        success: false,
-        error: error as Error, // should NOT be propagated to the user
-      }
-    }
-  }
-
-  async query(
-    params: ConnBaseQueryParams,
-  ): Promise<ConnQueryResult<Stream.Readable>> {
-    const query_id = this.getQueryId(params.query_id)
-    const clickhouse_settings = withHttpSettings(
-      params.clickhouse_settings,
-      this.params.compression.decompress_response,
-    )
-    const searchParams = toSearchParams({
-      database: this.params.database,
-      clickhouse_settings,
-      query_params: params.query_params,
-      session_id: params.session_id,
-      query_id,
-    })
-    const decompressResponse = clickhouse_settings.enable_http_compression === 1
-    const { controller, controllerCleanup } = this.getAbortController(params)
-    try {
-      const { stream } = await this.request(
-        {
-          method: 'POST',
-          url: transformUrl({ url: this.params.url, searchParams }),
-          body: params.query,
-          abort_signal: controller.signal,
-          decompress_response: decompressResponse,
-        },
-        'Query',
-      )
-      return {
-        stream,
-        query_id,
-      }
-    } catch (err) {
-      controller.abort('Query HTTP request failed')
-      this.logRequestError({
-        op: 'Query',
-        query_id: query_id,
-        query_params: params,
-        search_params: searchParams,
-        err: err as Error,
-        extra_args: {
-          decompress_response: decompressResponse,
-          clickhouse_settings,
-        },
-      })
-      throw err // should be propagated to the user
-    } finally {
-      controllerCleanup()
-    }
-  }
-
-  async exec(
-    params: ConnBaseQueryParams,
-  ): Promise<ConnExecResult<Stream.Readable>> {
-    const query_id = this.getQueryId(params.query_id)
-    const searchParams = toSearchParams({
-      database: this.params.database,
-      clickhouse_settings: params.clickhouse_settings,
-      query_params: params.query_params,
-      session_id: params.session_id,
-      query_id,
-    })
-    const { controller, controllerCleanup } = this.getAbortController(params)
-    try {
-      const { stream, summary } = await this.request(
-        {
-          method: 'POST',
-          url: transformUrl({ url: this.params.url, searchParams }),
-          body: params.query,
-          abort_signal: controller.signal,
-          parse_summary: true,
-        },
-        'Exec',
-      )
-      return {
-        stream,
-        query_id,
-        summary,
-      }
-    } catch (err) {
-      controller.abort('Exec HTTP request failed')
-      this.logRequestError({
-        op: 'Exec',
-        query_id: query_id,
-        query_params: params,
-        search_params: searchParams,
-        err: err as Error,
-        extra_args: {
-          clickhouse_settings: params.clickhouse_settings ?? {},
-        },
-      })
-      throw err // should be propagated to the user
-    } finally {
-      controllerCleanup()
-    }
-  }
-
-  async insert(
-    params: ConnInsertParams<Stream.Readable>,
-  ): Promise<ConnInsertResult> {
-    const query_id = this.getQueryId(params.query_id)
-    const searchParams = toSearchParams({
-      database: this.params.database,
-      clickhouse_settings: params.clickhouse_settings,
-      query_params: params.query_params,
-      query: params.query,
-      session_id: params.session_id,
-      query_id,
-    })
-    const { controller, controllerCleanup } = this.getAbortController(params)
-    try {
-      const { stream, summary } = await this.request(
-        {
-          method: 'POST',
-          url: transformUrl({ url: this.params.url, searchParams }),
-          body: params.values,
-          abort_signal: controller.signal,
-          compress_request: this.params.compression.compress_request,
-          parse_summary: true,
-        },
-        'Insert',
-      )
-      await drainStream(stream)
-      return { query_id, summary }
-    } catch (err) {
-      controller.abort('Insert HTTP request failed')
-      this.logRequestError({
-        op: 'Insert',
-        query_id: query_id,
-        query_params: params,
-        search_params: searchParams,
-        err: err as Error,
-        extra_args: {
-          clickhouse_settings: params.clickhouse_settings ?? {},
-        },
-      })
-      throw err // should be propagated to the user
-    } finally {
-      controllerCleanup()
-    }
-  }
-
-  async close(): Promise<void> {
-    if (this.agent !== undefined && this.agent.destroy !== undefined) {
-      this.agent.destroy()
-    }
-  }
-
-  private getQueryId(query_id: string | undefined): string {
-    return query_id || crypto.randomUUID()
-  }
-
-  // a wrapper over the user's Signal to terminate the failed requests
-  private getAbortController(params: ConnBaseQueryParams): {
-    controller: AbortController
-    controllerCleanup: () => void
-  } {
-    const controller = new AbortController()
-    function onAbort() {
-      controller.abort()
-    }
-    params.abort_signal?.addEventListener('abort', onAbort)
-    return {
-      controller,
-      controllerCleanup: () => {
-        params.abort_signal?.removeEventListener('abort', onAbort)
-      },
-    }
-  }
-
-  private logResponse(
-    op: ConnOperation,
-    request: Http.ClientRequest,
-    params: RequestParams,
-    response: Http.IncomingMessage,
-    startTimestamp: number,
-  ) {
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const { authorization, host, ...headers } = request.getHeaders()
-    const duration = Date.now() - startTimestamp
-    this.params.log_writer.debug({
-      module: 'HTTP Adapter',
-      message: `${op}: got a response from ClickHouse`,
-      args: {
-        request_method: params.method,
-        request_path: params.url.pathname,
-        request_params: params.url.search,
-        request_headers: headers,
-        response_status: response.statusCode,
-        response_headers: response.headers,
-        response_time_ms: duration,
-      },
-    })
-  }
-
-  private logRequestError({
-    op,
-    err,
-    query_id,
-    query_params,
-    search_params,
-    extra_args,
-  }: LogRequestErrorParams) {
-    this.logger.error({
-      message: this.httpRequestErrorMessage(op),
-      err: err as Error,
-      args: {
-        query: query_params.query,
-        search_params: search_params?.toString() ?? '',
-        with_abort_signal: query_params.abort_signal !== undefined,
-        session_id: query_params.session_id,
-        query_id: query_id,
-        ...extra_args,
-      },
-    })
-  }
-
-  private httpRequestErrorMessage(op: ConnOperation): string {
-    return `${op}: HTTP request error.`
-  }
-
-  private parseSummary(
-    op: ConnOperation,
-    response: Http.IncomingMessage,
-  ): ClickHouseSummary | undefined {
-    const summaryHeader = response.headers['x-clickhouse-summary']
-    if (typeof summaryHeader === 'string') {
-      try {
-        return JSON.parse(summaryHeader)
-      } catch (err) {
-        this.logger.error({
-          message: `${op}: failed to parse X-ClickHouse-Summary header.`,
-          args: {
-            'X-ClickHouse-Summary': summaryHeader,
-          },
-          err: err as Error,
-        })
-      }
-    }
-  }
 }
 
 interface RequestResult {
@@ -566,4 +586,8 @@ interface LogRequestErrorParams {
 interface SocketInfo {
   id: string
   idle_timeout_handle: ReturnType<typeof setTimeout> | undefined
+}
+
+type RunExecParams = ConnBaseQueryParams & {
+  op: 'Exec' | 'Command'
 }

--- a/packages/client-node/src/connection/node_base_connection.ts
+++ b/packages/client-node/src/connection/node_base_connection.ts
@@ -27,7 +27,7 @@ import Zlib from 'zlib'
 import { getAsText, getUserAgent, isStream } from '../utils'
 import { decompressResponse, isDecompressionError } from './compression'
 import { drainStream } from './stream'
-import type { ConnCommandResult } from '@clickhouse/client-common/src/connection'
+import type { ConnCommandResult } from '@clickhouse/client-common'
 
 export type NodeConnectionParams = ConnectionParams & {
   tls?: TLSParams

--- a/packages/client-web/src/config.ts
+++ b/packages/client-web/src/config.ts
@@ -18,5 +18,4 @@ export const WebImpl: ImplementationDetails<ReadableStream>['impl'] = {
     query_id: string,
   ) => new ResultSet(stream, format, query_id)) as any,
   values_encoder: new WebValuesEncoder(),
-  close_stream: (stream) => stream.cancel(),
 }

--- a/packages/client-web/src/connection/web_connection.ts
+++ b/packages/client-web/src/connection/web_connection.ts
@@ -16,7 +16,7 @@ import {
   withHttpSettings,
 } from '@clickhouse/client-common'
 import { getAsText } from '../utils'
-import type { ConnCommandResult } from '@clickhouse/client-common/src/connection'
+import type { ConnCommandResult } from '@clickhouse/client-common'
 
 type WebInsertParams<T> = Omit<
   ConnInsertParams<ReadableStream<T>>,

--- a/packages/client-web/src/connection/web_connection.ts
+++ b/packages/client-web/src/connection/web_connection.ts
@@ -1,5 +1,6 @@
 import type {
   ConnBaseQueryParams,
+  ConnCommandResult,
   Connection,
   ConnectionParams,
   ConnInsertParams,
@@ -16,7 +17,6 @@ import {
   withHttpSettings,
 } from '@clickhouse/client-common'
 import { getAsText } from '../utils'
-import type { ConnCommandResult } from '@clickhouse/client-common'
 
 type WebInsertParams<T> = Omit<
   ConnInsertParams<ReadableStream<T>>,


### PR DESCRIPTION
## Summary

The `command` method now drains the response stream properly, as the previous implementation could cause the Keep-Alive socket to close after each request.

## Checklist
- [x] Unit and integration tests covering the common scenarios were added
- [x] A human-readable description of the changes was provided to include in CHANGELOG
