### PR TITLE
Add missing property for `ResponseJSON<T>` type

### DIFF
--- a/packages/client-common/src/clickhouse_types.ts
+++ b/packages/client-common/src/clickhouse_types.ts
@@ -8,6 +8,7 @@ export interface ResponseJSON<T = unknown> {
   meta?: Array<{ name: string; type: string }>
   statistics?: { elapsed: number; rows_read: number; bytes_read: number }
   rows?: number
+  rows_before_limit_at_least?: number
 }
 
 export interface InputJSON<T = unknown> {


### PR DESCRIPTION
## Summary

The [`rows_before_limit_at_least`](https://clickhouse.com/docs/en/interfaces/formats#json) returned by ClickHouse was missing from the `ResponseJSON<T>` type.

Resolves: #267