### PR TITLE
Allow override session_id in exec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# UNRELEASED (Common, Node.js, Web)
+
+## Bug fixes
+
+- Allow overriding `session_id` per query ([@holi0317](https://github.com/Holi0317), [#271](https://github.com/ClickHouse/clickhouse-js/issues/271)).
+
 # 1.0.2 (Common, Node.js, Web)
 
 ## Bug fixes

--- a/packages/client-common/__tests__/integration/exec.test.ts
+++ b/packages/client-common/__tests__/integration/exec.test.ts
@@ -51,6 +51,19 @@ describe('exec', () => {
     })
   })
 
+  it('should use session_id override', async () => {
+    const session_id = guid()
+
+    // Temporary tables cannot be used without a session
+    const tableName = `temp_table_${guid()}`
+    await expectAsync(
+      runExec({
+        query: `CREATE TEMPORARY TABLE ${tableName} (val Int32)`,
+        session_id,
+      }),
+    ).toBeResolved()
+  })
+
   it('does not swallow ClickHouse error', async () => {
     const { ddl, tableName } = getDDL()
     const commands = async () => {
@@ -89,6 +102,25 @@ describe('exec', () => {
       await expectAsync(
         sessionClient.exec({
           query: `CREATE TEMPORARY TABLE ${tableName} (val Int32)`,
+        }),
+      ).toBeResolved()
+    })
+
+    it('should use override session_id', async () => {
+      const session_id = `test-session-override-${guid()}`
+
+      const tableName = `temp_table_${guid()}`
+      await expectAsync(
+        sessionClient.exec({
+          query: `CREATE TEMPORARY TABLE ${tableName} (val Int32)`,
+        }),
+      ).toBeResolved()
+
+      // This should fail with table already exist if override logic is not working
+      await expectAsync(
+        sessionClient.exec({
+          query: `CREATE TEMPORARY TABLE ${tableName} (val Int32)`,
+          session_id,
         }),
       ).toBeResolved()
     })

--- a/packages/client-common/src/client.ts
+++ b/packages/client-common/src/client.ts
@@ -156,9 +156,10 @@ export class ClickHouseClient<Stream = unknown> {
   ): Promise<QueryResult<Stream, Format>> {
     const format = params.format ?? 'JSON'
     const query = formatQuery(params.query, format)
+    const queryParams = this.withClientQueryParams(params)
     const { stream, query_id } = await this.connection.query({
       query,
-      ...this.withClientQueryParams(params),
+      ...queryParams,
     })
     return this.makeResultSet(stream, format, query_id, (err) => {
       this.logWriter.error({
@@ -166,7 +167,7 @@ export class ClickHouseClient<Stream = unknown> {
         module: 'Client',
         message: 'Error while processing the ResultSet.',
         args: {
-          session_id: this.sessionId,
+          session_id: queryParams.session_id,
           query,
           query_id,
         },

--- a/packages/client-common/src/client.ts
+++ b/packages/client-common/src/client.ts
@@ -25,6 +25,8 @@ export interface BaseQueryParams {
   /** A specific `query_id` that will be sent with this request.
    * If it is not set, a random identifier will be generated automatically by the client. */
   query_id?: string
+  /** A specific `session_id` for this query
+   * If it is not set, the client's session_id will be used. */
   session_id?: string
 }
 
@@ -250,7 +252,7 @@ export class ClickHouseClient<Stream = unknown> {
       query_params: params.query_params,
       abort_signal: params.abort_signal,
       query_id: params.query_id,
-      session_id: this.sessionId,
+      session_id: params.session_id ?? this.sessionId,
     }
   }
 }


### PR DESCRIPTION
## Summary

Allow overriding `session_id` per query

https://github.com/ClickHouse/clickhouse-js/issues/271

## Checklist
Delete items not relevant to your PR:
- [x] Unit and integration tests covering the common scenarios were added
- [x] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
