### PR TITLE
chore: allow passing a socket connection to https.Agent

### DIFF
--- a/packages/client-common/src/config.ts
+++ b/packages/client-common/src/config.ts
@@ -1,3 +1,4 @@
+import type internal from 'stream'
 import type { InsertValues } from './client'
 import type { Connection, ConnectionParams } from './connection'
 import type { DataFormat } from './data_formatter'
@@ -76,6 +77,9 @@ export interface BaseClickHouseClientConfigOptions {
      *  @default true */
     enabled?: boolean
   }
+  /** Socket connection for https.Agent override - helpful when connecting through a proxy
+   *  @default undefined */
+  socket?: internal.Duplex
 }
 
 export type MakeConnection<
@@ -216,6 +220,7 @@ export function getConnectionParams(
     keep_alive: { enabled: config.keep_alive?.enabled ?? true },
     clickhouse_settings: config.clickhouse_settings ?? {},
     http_headers: config.http_headers ?? {},
+    socket: config.socket ?? undefined,
   }
 }
 

--- a/packages/client-common/src/connection.ts
+++ b/packages/client-common/src/connection.ts
@@ -1,6 +1,7 @@
 import type { WithClickHouseSummary } from './clickhouse_types'
 import type { LogWriter } from './logger'
 import type { ClickHouseSettings } from './settings'
+import type internal from 'stream'
 
 export interface ConnectionParams {
   url: URL
@@ -15,6 +16,7 @@ export interface ConnectionParams {
   keep_alive: { enabled: boolean }
   application_id?: string
   http_headers?: Record<string, string>
+  socket?: internal.Duplex
 }
 
 export interface CompressionSettings {

--- a/packages/client-node/src/connection/node_https_connection.ts
+++ b/packages/client-node/src/connection/node_https_connection.ts
@@ -15,6 +15,7 @@ export class NodeHttpsConnection extends NodeBaseConnection {
       ca: params.tls?.ca_cert,
       key: params.tls?.type === 'Mutual' ? params.tls.key : undefined,
       cert: params.tls?.type === 'Mutual' ? params.tls.cert : undefined,
+      socket: params.socket,
     })
     super(params, agent)
   }


### PR DESCRIPTION
chore: allow passing a socket connection to https.Agent

## Summary
A short description of the changes with a link to an open issue.

## Checklist
Delete items not relevant to your PR:
- [ ] Unit and integration tests covering the common scenarios were added
- [ ] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
