### PR TITLE
Change incorrect totals TS type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,11 @@
 
 ## New features
 
-- Added an option to override the credentials for a particular `query`/`command`/`exec`/`insert` request via the `BaseQueryParams.auth` setting; when set, the credentials will be taken from there instead of the username/password provided during the client instantiation.
+- Added an option to override the credentials for a particular `query`/`command`/`exec`/`insert` request via the `BaseQueryParams.auth` setting; when set, the credentials will be taken from there instead of the username/password provided during the client instantiation ([#278](https://github.com/ClickHouse/clickhouse-js/issues/278)).
+
+## Bug fixes
+
+- Fixed the incorrect `ResponseJSON<T>.totals` TypeScript type. Now it correctly matches the shape of the data (`T`, default = `unknown`) instead of the former `Record<string, number>` definition ([#274](https://github.com/ClickHouse/clickhouse-js/issues/274)).
 
 # 1.0.2 (Common, Node.js, Web)
 

--- a/packages/client-common/__tests__/integration/totals.test.ts
+++ b/packages/client-common/__tests__/integration/totals.test.ts
@@ -2,7 +2,7 @@ import type { ClickHouseClient } from '@clickhouse/client-common'
 import { createSimpleTable } from '@test/fixtures/simple_table'
 import { createTestClient, guid } from '@test/utils'
 
-fdescribe('Queries with totals', () => {
+describe('Queries with totals', () => {
   let client: ClickHouseClient
   let tableName: string
 

--- a/packages/client-common/__tests__/integration/totals.test.ts
+++ b/packages/client-common/__tests__/integration/totals.test.ts
@@ -48,15 +48,16 @@ fdescribe('Queries with totals', () => {
     })
 
     const rs2 = await client.query({
-      query: `SELECT name, count(*) AS count FROM ${tableName} GROUP BY name WITH TOTALS ORDER BY name ASC`,
+      query: `SELECT 1 :: Int16 AS x, name, count(*) AS count FROM ${tableName} GROUP BY name WITH TOTALS ORDER BY name ASC`,
       format: 'JSON',
     })
     const result2 = await rs2.json()
     expect(result2.data).toEqual([
-      { name: 'foo', count: '3' },
-      { name: 'hello', count: '2' },
+      { x: 1, name: 'foo', count: '3' },
+      { x: 1, name: 'hello', count: '2' },
     ])
     expect(result2.totals).toEqual({
+      x: 1,
       name: '',
       count: '5',
     })

--- a/packages/client-common/__tests__/integration/totals.test.ts
+++ b/packages/client-common/__tests__/integration/totals.test.ts
@@ -1,0 +1,64 @@
+import type { ClickHouseClient } from '@clickhouse/client-common'
+import { createSimpleTable } from '@test/fixtures/simple_table'
+import { createTestClient, guid } from '@test/utils'
+
+fdescribe('Queries with totals', () => {
+  let client: ClickHouseClient
+  let tableName: string
+
+  beforeEach(async () => {
+    client = createTestClient()
+    tableName = `totals_test_${guid()}`
+    await createSimpleTable(client, tableName)
+  })
+  afterEach(async () => {
+    await client.close()
+  })
+
+  it('should return the expected totals', async () => {
+    await client.insert({
+      table: tableName,
+      values: [
+        { id: '42', name: 'hello', sku: [0, 1] },
+        { id: '43', name: 'hello', sku: [2, 3] },
+        { id: '44', name: 'foo', sku: [3, 4] },
+        { id: '45', name: 'foo', sku: [4, 5] },
+        { id: '46', name: 'foo', sku: [6, 7] },
+      ],
+      format: 'JSONEachRow',
+    })
+
+    const rs1 = await client.query({
+      query: `SELECT *, count(*) AS count FROM ${tableName} GROUP BY id, name, sku WITH TOTALS ORDER BY id ASC`,
+      format: 'JSON',
+    })
+    const result1 = await rs1.json()
+    expect(result1.data).toEqual([
+      { id: '42', name: 'hello', sku: [0, 1], count: '1' },
+      { id: '43', name: 'hello', sku: [2, 3], count: '1' },
+      { id: '44', name: 'foo', sku: [3, 4], count: '1' },
+      { id: '45', name: 'foo', sku: [4, 5], count: '1' },
+      { id: '46', name: 'foo', sku: [6, 7], count: '1' },
+    ])
+    expect(result1.totals).toEqual({
+      id: '0',
+      name: '',
+      sku: [],
+      count: '5',
+    })
+
+    const rs2 = await client.query({
+      query: `SELECT name, count(*) AS count FROM ${tableName} GROUP BY name WITH TOTALS ORDER BY name ASC`,
+      format: 'JSON',
+    })
+    const result2 = await rs2.json()
+    expect(result2.data).toEqual([
+      { name: 'foo', count: '3' },
+      { name: 'hello', count: '2' },
+    ])
+    expect(result2.totals).toEqual({
+      name: '',
+      count: '5',
+    })
+  })
+})

--- a/packages/client-common/src/clickhouse_types.ts
+++ b/packages/client-common/src/clickhouse_types.ts
@@ -1,7 +1,7 @@
 export interface ResponseJSON<T = unknown> {
   data: Array<T>
   query_id?: string
-  totals?: Record<string, number>
+  totals?: T
   extremes?: Record<string, any>
   // # Supported only by responses in JSON, XML.
   // # Otherwise, it can be read from x-clickhouse-summary header

--- a/packages/client-node/__tests__/integration/node_errors_parsing.test.ts
+++ b/packages/client-node/__tests__/integration/node_errors_parsing.test.ts
@@ -3,7 +3,7 @@ import { createClient } from '../../src'
 describe('[Node.js] errors parsing', () => {
   it('should return an error when URL is unreachable', async () => {
     const client = createClient({
-      host: 'http://localhost:1111',
+      url: 'http://localhost:1111',
     })
     await expectAsync(
       client.query({

--- a/packages/client-node/__tests__/integration/node_ping.test.ts
+++ b/packages/client-node/__tests__/integration/node_ping.test.ts
@@ -8,7 +8,7 @@ describe('[Node.js] ping', () => {
   })
   it('does not swallow a client error', async () => {
     client = createTestClient({
-      host: 'http://localhost:3333',
+      url: 'http://localhost:3333',
     })
 
     const result = await client.ping()

--- a/packages/client-web/__tests__/integration/web_error_parsing.test.ts
+++ b/packages/client-web/__tests__/integration/web_error_parsing.test.ts
@@ -3,7 +3,7 @@ import { createClient } from '../../src'
 describe('[Web] errors parsing', () => {
   it('should return an error when URL is unreachable', async () => {
     const client = createClient({
-      host: 'http://localhost:1111',
+      url: 'http://localhost:1111',
     })
     await expectAsync(
       client.query({

--- a/packages/client-web/__tests__/integration/web_ping.test.ts
+++ b/packages/client-web/__tests__/integration/web_ping.test.ts
@@ -8,7 +8,7 @@ describe('[Web] ping', () => {
   })
   it('does not swallow a client error', async () => {
     client = createTestClient({
-      host: 'http://localhost:3333',
+      url: 'http://localhost:3333',
     })
 
     const result = await client.ping()


### PR DESCRIPTION
## Summary

Resolves #274

`ResponseJSON<T>.totals` should match `T` instead of the `Record<string, number>` definition.

## Checklist
- [x] Unit and integration tests covering the common scenarios were added
- [x] A human-readable description of the changes was provided to include in CHANGELOG
