### PR TITLE
Allow to provide a custom http agent and disable the auth header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,11 @@
 
 ## New features
 
-- Added an option to provide a custom HTTP Agent in the client configuration via the `http_agent` option ([#283](https://github.com/ClickHouse/clickhouse-js/issues/283), related: [#278](https://github.com/ClickHouse/clickhouse-js/issues/278)). The following conditions apply if a custom HTTP Agent is provided:
+- (Experimental) Added an option to provide a custom HTTP Agent in the client configuration via the `http_agent` option ([#283](https://github.com/ClickHouse/clickhouse-js/issues/283), related: [#278](https://github.com/ClickHouse/clickhouse-js/issues/278)). The following conditions apply if a custom HTTP Agent is provided:
   - The `max_open_connections` and `tls` options will have _no effect_ and will be ignored by the client, as it is a part of the underlying HTTP Agent configuration.
   - `keep_alive.enabled` will only regulate the default value of the `Connection` header (`true` -> `Connection: keep-alive`, `false` -> `Connection: close`).
   - While the idle socket management will still work, it is now possible to disable it completely by setting the `keep_alive.idle_socket_ttl` value to `0`.
-- Added a new client configuration option: `set_basic_auth_header`, which disables the `Authorization` header that is set by the client by default for every outgoing HTTP request. One of the possible scenarios when it is necessary to disable this header is when a custom HTTPS agent is used, and the server requires TLS authorization. For example:
+- (Experimental) Added a new client configuration option: `set_basic_auth_header`, which disables the `Authorization` header that is set by the client by default for every outgoing HTTP request. One of the possible scenarios when it is necessary to disable this header is when a custom HTTPS agent is used, and the server requires TLS authorization. For example:
 
   ```ts
   const agent = new https.Agent({
@@ -26,6 +26,8 @@
   ```
 
 NB: It is currently not possible to set the `set_basic_auth_header` option via the URL params.
+
+If you have feedback on these experimental features, please let us know by creating [an issue](https://github.com/ClickHouse/clickhouse-js/issues) in the repository.
 
 # 1.1.0 (Common, Node.js, Web)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,32 @@
+# 1.2.0 (Node.js)
+
+## New features
+
+- Added an option to provide a custom HTTP Agent in the client configuration via the `http_agent` option ([#283](https://github.com/ClickHouse/clickhouse-js/issues/283), related: [#278](https://github.com/ClickHouse/clickhouse-js/issues/278)). The following conditions apply if a custom HTTP Agent is provided:
+  - The `max_open_connections` and `tls` options will have _no effect_ and will be ignored by the client, as it is a part of the underlying HTTP Agent configuration.
+  - `keep_alive.enabled` will only regulate the default value of the `Connection` header (`true` -> `Connection: keep-alive`, `false` -> `Connection: close`).
+  - While the idle socket management will still work, it is now possible to disable it completely by setting the `keep_alive.idle_socket_ttl` value to `0`.
+- Added a new client configuration option: `set_basic_auth_header`, which disables the `Authorization` header that is set by the client by default for every outgoing HTTP request. One of the possible scenarios when it is necessary to disable this header is when a custom HTTPS agent is used, and the server requires TLS authorization. For example:
+
+  ```ts
+  const agent = new https.Agent({
+    ca: fs.readFileSync('./ca.crt'),
+  })
+  const client = createClient({
+    url: 'https://server.clickhouseconnect.test:8443',
+    http_agent: agent,
+    // With a custom HTTPS agent, the client won't use the default HTTPS connection implementation; the headers should be provided manually
+    http_headers: {
+      'X-ClickHouse-User': 'default',
+      'X-ClickHouse-Key': '',
+    },
+    // Authorization header conflicts with the TLS headers; disable it.
+    set_basic_auth_header: false,
+  })
+  ```
+
+NB: It is currently not possible to set the `set_basic_auth_header` option via the URL params.
+
 # 1.1.0 (Common, Node.js, Web)
 
 ## New features

--- a/packages/client-common/src/version.ts
+++ b/packages/client-common/src/version.ts
@@ -1,1 +1,1 @@
-export default '1.1.0'
+export default '1.2.0'

--- a/packages/client-node/__tests__/integration/node_custom_http_agent.test.ts
+++ b/packages/client-node/__tests__/integration/node_custom_http_agent.test.ts
@@ -1,0 +1,28 @@
+import http from 'http'
+import Http from 'http'
+import { createClient } from '../../src'
+
+/** HTTPS agent tests are in tls.test.ts as it requires a secure connection. */
+describe('[Node.js] custom HTTP agent', () => {
+  let httpRequestStub: jasmine.Spy<typeof Http.request>
+  beforeEach(() => {
+    httpRequestStub = spyOn(Http, 'request').and.callThrough()
+  })
+
+  it('should use provided http agent instead of the default one', async () => {
+    const agent = new http.Agent({
+      maxFreeSockets: 5,
+    })
+    const client = createClient({
+      http_agent: agent,
+    })
+    const rs = await client.query({
+      query: 'SELECT 42 AS result',
+      format: 'JSONEachRow',
+    })
+    expect(await rs.json()).toEqual([{ result: 42 }])
+    expect(httpRequestStub).toHaveBeenCalledTimes(1)
+    const callArgs = httpRequestStub.calls.mostRecent().args
+    expect(callArgs[1].agent).toBe(agent)
+  })
+})

--- a/packages/client-node/__tests__/integration/node_custom_http_agent.test.ts
+++ b/packages/client-node/__tests__/integration/node_custom_http_agent.test.ts
@@ -1,3 +1,4 @@
+import { TestEnv, whenOnEnv } from '@test/utils'
 import http from 'http'
 import Http from 'http'
 import { createClient } from '../../src'
@@ -9,20 +10,24 @@ describe('[Node.js] custom HTTP agent', () => {
     httpRequestStub = spyOn(Http, 'request').and.callThrough()
   })
 
-  it('should use provided http agent instead of the default one', async () => {
-    const agent = new http.Agent({
-      maxFreeSockets: 5,
-    })
-    const client = createClient({
-      http_agent: agent,
-    })
-    const rs = await client.query({
-      query: 'SELECT 42 AS result',
-      format: 'JSONEachRow',
-    })
-    expect(await rs.json()).toEqual([{ result: 42 }])
-    expect(httpRequestStub).toHaveBeenCalledTimes(1)
-    const callArgs = httpRequestStub.calls.mostRecent().args
-    expect(callArgs[1].agent).toBe(agent)
-  })
+  // disabled with Cloud as it uses a simple HTTP agent
+  whenOnEnv(TestEnv.LocalSingleNode, TestEnv.LocalCluster).it(
+    'should use provided http agent instead of the default one',
+    async () => {
+      const agent = new http.Agent({
+        maxFreeSockets: 5,
+      })
+      const client = createClient({
+        http_agent: agent,
+      })
+      const rs = await client.query({
+        query: 'SELECT 42 AS result',
+        format: 'JSONEachRow',
+      })
+      expect(await rs.json()).toEqual([{ result: 42 }])
+      expect(httpRequestStub).toHaveBeenCalledTimes(1)
+      const callArgs = httpRequestStub.calls.mostRecent().args
+      expect(callArgs[1].agent).toBe(agent)
+    },
+  )
 })

--- a/packages/client-node/__tests__/unit/node_client.test.ts
+++ b/packages/client-node/__tests__/unit/node_client.test.ts
@@ -4,6 +4,7 @@ import type {
 } from '@clickhouse/client-common'
 import { DefaultLogger, LogWriter } from '@clickhouse/client-common'
 import { createClient } from '../../src'
+import type { CreateConnectionParams } from '../../src/connection'
 import * as c from '../../src/connection/create_connection'
 
 describe('[Node.js] createClient', () => {
@@ -66,14 +67,16 @@ describe('[Node.js] createClient', () => {
             'keep_alive_idle_socket_ttl=1500',
           ].join('&'),
       })
-      expect(createConnectionStub).toHaveBeenCalledWith(
-        params,
-        undefined, // TLS
-        {
+      expect(createConnectionStub).toHaveBeenCalledWith({
+        connection_params: params,
+        tls: undefined,
+        keep_alive: {
           enabled: true,
           idle_socket_ttl: 1500,
         },
-      )
+        set_basic_auth_header: true,
+        http_agent: undefined,
+      } satisfies CreateConnectionParams)
       expect(createConnectionStub).toHaveBeenCalledTimes(1)
     })
 
@@ -91,14 +94,19 @@ describe('[Node.js] createClient', () => {
             'keep_alive_idle_socket_ttl=1500',
           ].join('&'),
       })
-      expect(createConnectionStub).toHaveBeenCalledWith(
-        { ...params, url: new URL('https://my.host:8443/my_proxy') },
-        undefined, // TLS
-        {
+      expect(createConnectionStub).toHaveBeenCalledWith({
+        connection_params: {
+          ...params,
+          url: new URL('https://my.host:8443/my_proxy'),
+        },
+        tls: undefined,
+        keep_alive: {
           enabled: true,
           idle_socket_ttl: 1500,
         },
-      )
+        set_basic_auth_header: true,
+        http_agent: undefined,
+      } satisfies CreateConnectionParams)
       expect(createConnectionStub).toHaveBeenCalledTimes(1)
     })
   })

--- a/packages/client-node/__tests__/unit/node_create_connection.test.ts
+++ b/packages/client-node/__tests__/unit/node_create_connection.test.ts
@@ -1,10 +1,13 @@
 import type { ConnectionParams } from '@clickhouse/client-common'
+import http from 'http'
+import https from 'node:https'
 import {
   createConnection,
   type NodeConnectionParams,
   NodeHttpConnection,
   NodeHttpsConnection,
 } from '../../src/connection'
+import { NodeCustomAgentConnection } from '../../src/connection/node_custom_agent_connection'
 
 describe('[Node.js] createConnection', () => {
   const keepAliveParams: NodeConnectionParams['keep_alive'] = {
@@ -16,34 +19,74 @@ describe('[Node.js] createConnection', () => {
   it('should create an instance of HTTP adapter', async () => {
     expect(adapter).toBeInstanceOf(NodeHttpConnection)
   })
-  const adapter = createConnection(
-    {
+  const adapter = createConnection({
+    connection_params: {
       url: new URL('http://localhost'),
     } as ConnectionParams,
-    tlsParams,
-    keepAliveParams,
-  )
+    tls: tlsParams,
+    keep_alive: keepAliveParams,
+    http_agent: undefined,
+    set_basic_auth_header: true,
+  })
 
   it('should create an instance of HTTPS adapter', async () => {
-    const adapter = createConnection(
-      {
+    const adapter = createConnection({
+      connection_params: {
         url: new URL('https://localhost'),
       } as ConnectionParams,
-      tlsParams,
-      keepAliveParams,
-    )
+      tls: tlsParams,
+      keep_alive: keepAliveParams,
+      http_agent: undefined,
+      set_basic_auth_header: true,
+    })
     expect(adapter).toBeInstanceOf(NodeHttpsConnection)
   })
 
   it('should throw if the supplied protocol is unknown', async () => {
     expect(() =>
-      createConnection(
-        {
+      createConnection({
+        connection_params: {
           url: new URL('tcp://localhost'),
         } as ConnectionParams,
-        tlsParams,
-        keepAliveParams,
-      ),
+        tls: tlsParams,
+        keep_alive: keepAliveParams,
+        http_agent: undefined,
+        set_basic_auth_header: true,
+      }),
     ).toThrowError('Only HTTP and HTTPS protocols are supported')
+  })
+
+  describe('Custom HTTP agent', () => {
+    it('should create an instance with a custom HTTP agent', async () => {
+      const adapter = createConnection({
+        connection_params: {
+          url: new URL('https://localhost'),
+        } as ConnectionParams,
+        tls: tlsParams,
+        keep_alive: keepAliveParams,
+        http_agent: new http.Agent({
+          keepAlive: true,
+          maxSockets: 2,
+        }),
+        set_basic_auth_header: false,
+      })
+      expect(adapter).toBeInstanceOf(NodeCustomAgentConnection)
+    })
+
+    it('should create an instance with a custom HTTPS agent', async () => {
+      const adapter = createConnection({
+        connection_params: {
+          url: new URL('https://localhost'),
+        } as ConnectionParams,
+        tls: tlsParams,
+        keep_alive: keepAliveParams,
+        http_agent: new https.Agent({
+          keepAlive: true,
+          maxSockets: 2,
+        }),
+        set_basic_auth_header: true,
+      })
+      expect(adapter).toBeInstanceOf(NodeCustomAgentConnection)
+    })
   })
 })

--- a/packages/client-node/__tests__/utils/http_stubs.ts
+++ b/packages/client-node/__tests__/utils/http_stubs.ts
@@ -113,6 +113,7 @@ export function buildHttpConnection(config: Partial<NodeConnectionParams>) {
       enabled: false,
       idle_socket_ttl: 2500,
     },
+    set_basic_auth_header: true,
     ...config,
   })
 }
@@ -126,6 +127,7 @@ export class MyTestHttpConnection extends NodeBaseConnection {
         keep_alive: {
           enabled: false,
         },
+        set_basic_auth_header: true,
       } as NodeConnectionParams,
       {} as Http.Agent,
     )

--- a/packages/client-node/src/config.ts
+++ b/packages/client-node/src/config.ts
@@ -31,9 +31,12 @@ export type NodeClickHouseClientConfigOptions =
     }
     /** Custom HTTP agent to use for the outgoing HTTP(s) requests.
      *  If set, {@link BaseClickHouseClientConfigOptions.max_open_connections}, {@link tls} and {@link keep_alive}
-     *  options have no effect, as it is part of the default underlying agent configuration. */
+     *  options have no effect, as it is part of the default underlying agent configuration.
+     *  @experimental - unstable API, might be a subject to change in the future; please provide your feedback in the repository.
+     *  @default undefined */
     http_agent?: http.Agent | https.Agent
     /** Enable or disable the `Authorization` header with basic auth for the outgoing HTTP(s) requests.
+     *  @experimental - unstable API, might be a subject to change in the future; please provide your feedback in the repository.
      *  @default true (enabled) */
     set_basic_auth_header?: boolean
   }

--- a/packages/client-node/src/connection/create_connection.ts
+++ b/packages/client-node/src/connection/create_connection.ts
@@ -1,21 +1,51 @@
 import type { ConnectionParams } from '@clickhouse/client-common'
+import type http from 'http'
+import type https from 'node:https'
 import type {
   NodeBaseConnection,
   NodeConnectionParams,
 } from './node_base_connection'
+import { NodeCustomAgentConnection } from './node_custom_agent_connection'
 import { NodeHttpConnection } from './node_http_connection'
 import { NodeHttpsConnection } from './node_https_connection'
 
-export function createConnection(
-  params: ConnectionParams,
-  tls: NodeConnectionParams['tls'],
-  keep_alive: NodeConnectionParams['keep_alive'],
-): NodeBaseConnection {
-  switch (params.url.protocol) {
+export interface CreateConnectionParams {
+  connection_params: ConnectionParams
+  tls: NodeConnectionParams['tls']
+  keep_alive: NodeConnectionParams['keep_alive']
+  http_agent: http.Agent | https.Agent | undefined
+  set_basic_auth_header: boolean
+}
+
+export function createConnection({
+  connection_params,
+  tls,
+  keep_alive,
+  http_agent,
+  set_basic_auth_header,
+}: CreateConnectionParams): NodeBaseConnection {
+  if (http_agent !== undefined) {
+    return new NodeCustomAgentConnection({
+      ...connection_params,
+      set_basic_auth_header,
+      keep_alive, // only used to enforce proper KeepAlive headers
+      http_agent,
+    })
+  }
+  switch (connection_params.url.protocol) {
     case 'http:':
-      return new NodeHttpConnection({ ...params, keep_alive })
+      return new NodeHttpConnection({
+        ...connection_params,
+        set_basic_auth_header,
+        keep_alive,
+      })
     case 'https:':
-      return new NodeHttpsConnection({ ...params, tls, keep_alive })
+      return new NodeHttpsConnection({
+        ...connection_params,
+        set_basic_auth_header,
+        keep_alive,
+        tls,
+      })
     default:
       throw new Error('Only HTTP and HTTPS protocols are supported')
   }

--- a/packages/client-node/src/connection/node_base_connection.ts
+++ b/packages/client-node/src/connection/node_base_connection.ts
@@ -21,10 +21,9 @@ import {
   withHttpSettings,
 } from '@clickhouse/client-common'
 import crypto from 'crypto'
-import type http from 'http'
 import type Http from 'http'
 import type * as net from 'net'
-import type https from 'node:https'
+import type Https from 'node:https'
 import Stream from 'stream'
 import type { URLSearchParams } from 'url'
 import Zlib from 'zlib'
@@ -34,7 +33,7 @@ import { drainStream } from './stream'
 
 export type NodeConnectionParams = ConnectionParams & {
   tls?: TLSParams
-  http_agent?: http.Agent | https.Agent
+  http_agent?: Http.Agent | Https.Agent
   set_basic_auth_header: boolean
   keep_alive: {
     enabled: boolean

--- a/packages/client-node/src/connection/node_custom_agent_connection.ts
+++ b/packages/client-node/src/connection/node_custom_agent_connection.ts
@@ -1,0 +1,33 @@
+import { withCompressionHeaders } from '@clickhouse/client-common'
+import Http from 'http'
+import type {
+  NodeConnectionParams,
+  RequestParams,
+} from './node_base_connection'
+import { NodeBaseConnection } from './node_base_connection'
+
+export class NodeCustomAgentConnection extends NodeBaseConnection {
+  constructor(params: NodeConnectionParams) {
+    if (!params.http_agent) {
+      throw new Error(
+        'http_agent is required to create NodeCustomAgentConnection',
+      )
+    }
+    super(params, params.http_agent)
+  }
+
+  protected createClientRequest(params: RequestParams): Http.ClientRequest {
+    const headers = withCompressionHeaders({
+      headers: params.headers,
+      compress_request: params.compress_request,
+      decompress_response: params.decompress_response,
+    })
+    return Http.request(params.url, {
+      method: params.method,
+      agent: this.agent,
+      timeout: this.params.request_timeout,
+      signal: params.abort_signal,
+      headers,
+    })
+  }
+}

--- a/packages/client-node/src/version.ts
+++ b/packages/client-node/src/version.ts
@@ -1,1 +1,1 @@
-export default '1.1.0'
+export default '1.2.0'

--- a/packages/client-web/src/version.ts
+++ b/packages/client-web/src/version.ts
@@ -1,1 +1,1 @@
-export default '1.1.0'
+export default '1.2.0'


### PR DESCRIPTION
## New features

- Added an option to provide a custom HTTP Agent in the client configuration via the `http_agent` option ([#283](https://github.com/ClickHouse/clickhouse-js/issues/283), related: [#278](https://github.com/ClickHouse/clickhouse-js/issues/278)). The following conditions apply if a custom HTTP Agent is provided:
  - The `max_open_connections` and `tls` options will have _no effect_ and will be ignored by the client, as it is a part of the underlying (default) HTTP Agent configuration.
  - `keep_alive.enabled` will only regulate the default value of the `Connection` header (`true` -> `Connection: keep-alive`, `false` -> `Connection: close`).
  - While the idle socket management will still work, it is now possible to disable it completely by setting the `keep_alive.idle_socket_ttl` value to `0`.
- Added a new client configuration option: `set_basic_auth_header` which disables the `Authorization` header that is set by the client by default for every outgoing HTTP request. One of the possible scenarios when it is necessary to disable this header is when a custom HTTPS agent is used, and the server requires TLS authorization with certificates. For example:

  ```ts
  const agent = new https.Agent({
    ca: fs.readFileSync('./ca.crt'),
  })
  const client = createClient({
    url: 'https://server.clickhouseconnect.test:8443',
    http_agent: agent,
    // With a custom HTTPS agent, the client won't use the default HTTPS connection implementation; the basic TLS headers should be provided manually
    http_headers: {
      'X-ClickHouse-User': 'default',
      'X-ClickHouse-Key': '',
    },
    // Authorization header conflicts with the TLS headers; disable it.
    set_basic_auth_header: false,
  })
  ```

NB: It is currently not possible to set the `set_basic_auth_header` option via the URL params.


## Checklist
- [x] Unit and integration tests covering the common scenarios were added
- [x] A human-readable description of the changes was provided to include in CHANGELOG
- [x] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials - https://github.com/ClickHouse/clickhouse-docs/pull/2412
