### PR TITLE
Re-export supported formats literals

### DIFF
--- a/packages/client-common/src/data_formatter/formatter.ts
+++ b/packages/client-common/src/data_formatter/formatter.ts
@@ -1,4 +1,4 @@
-const streamableJSONFormats = [
+export const StreamableJSONFormats = [
   'JSONEachRow',
   'JSONStringsEachRow',
   'JSONCompactEachRow',
@@ -8,20 +8,20 @@ const streamableJSONFormats = [
   'JSONCompactStringsEachRowWithNames',
   'JSONCompactStringsEachRowWithNamesAndTypes',
 ] as const
-const recordsJSONFormats = ['JSONObjectEachRow'] as const
-const singleDocumentJSONFormats = [
+export const RecordsJSONFormats = ['JSONObjectEachRow'] as const
+export const SingleDocumentJSONFormats = [
   'JSON',
   'JSONStrings',
   'JSONCompact',
   'JSONCompactStrings',
   'JSONColumnsWithMetadata',
 ] as const
-const supportedJSONFormats = [
-  ...recordsJSONFormats,
-  ...singleDocumentJSONFormats,
-  ...streamableJSONFormats,
+export const SupportedJSONFormats = [
+  ...RecordsJSONFormats,
+  ...SingleDocumentJSONFormats,
+  ...StreamableJSONFormats,
 ] as const
-const supportedRawFormats = [
+export const SupportedRawFormats = [
   'CSV',
   'CSVWithNames',
   'CSVWithNamesAndTypes',
@@ -34,20 +34,24 @@ const supportedRawFormats = [
   'CustomSeparatedWithNamesAndTypes',
   'Parquet',
 ] as const
+export const StreamableFormats = [
+  ...StreamableJSONFormats,
+  ...SupportedRawFormats,
+] as const
 
 /** CSV, TSV, etc. - can be streamed, but cannot be decoded as JSON. */
-export type RawDataFormat = (typeof supportedRawFormats)[number]
+export type RawDataFormat = (typeof SupportedRawFormats)[number]
 
 /** Each row is returned as a separate JSON object or an array, and these formats can be streamed. */
-export type StreamableJSONDataFormat = (typeof streamableJSONFormats)[number]
+export type StreamableJSONDataFormat = (typeof StreamableJSONFormats)[number]
 
 /** Returned as a single {@link ResponseJSON} object, cannot be streamed. */
 export type SingleDocumentJSONFormat =
-  (typeof singleDocumentJSONFormats)[number]
+  (typeof SingleDocumentJSONFormats)[number]
 
 /** Returned as a single object { row_1: T, row_2: T, ...} <br/>
  *  (i.e. Record<string, T>), cannot be streamed. */
-export type RecordsJSONFormat = (typeof recordsJSONFormats)[number]
+export type RecordsJSONFormat = (typeof RecordsJSONFormats)[number]
 
 /** All allowed JSON formats, whether streamable or not. */
 export type JSONDataFormat =
@@ -66,39 +70,34 @@ export type JSONDataFormat =
  *  @see https://clickhouse.com/docs/en/interfaces/formats */
 export type DataFormat = JSONDataFormat | RawDataFormat
 
-const streamableFormat = [
-  ...streamableJSONFormats,
-  ...supportedRawFormats,
-] as const
-
 /** All data formats that can be streamed, whether it can be decoded as JSON or not. */
-export type StreamableDataFormat = (typeof streamableFormat)[number]
+export type StreamableDataFormat = (typeof StreamableFormats)[number]
 
 export function isNotStreamableJSONFamily(
   format: DataFormat,
 ): format is SingleDocumentJSONFormat {
   return (
-    (singleDocumentJSONFormats as readonly string[]).includes(format) ||
-    (recordsJSONFormats as readonly string[]).includes(format)
+    (SingleDocumentJSONFormats as readonly string[]).includes(format) ||
+    (RecordsJSONFormats as readonly string[]).includes(format)
   )
 }
 
 export function isStreamableJSONFamily(
   format: DataFormat,
 ): format is StreamableJSONDataFormat {
-  return (streamableJSONFormats as readonly string[]).includes(format)
+  return (StreamableJSONFormats as readonly string[]).includes(format)
 }
 
 export function isSupportedRawFormat(dataFormat: DataFormat) {
-  return (supportedRawFormats as readonly string[]).includes(dataFormat)
+  return (SupportedRawFormats as readonly string[]).includes(dataFormat)
 }
 
 export function validateStreamFormat(
   format: any,
 ): format is StreamableDataFormat {
-  if (!streamableFormat.includes(format)) {
+  if (!StreamableFormats.includes(format)) {
     throw new Error(
-      `${format} format is not streamable. Streamable formats: ${streamableFormat.join(
+      `${format} format is not streamable. Streamable formats: ${StreamableFormats.join(
         ',',
       )}`,
     )
@@ -113,7 +112,7 @@ export function validateStreamFormat(
  * @returns string
  */
 export function encodeJSON(value: any, format: DataFormat): string {
-  if ((supportedJSONFormats as readonly string[]).includes(format)) {
+  if ((SupportedJSONFormats as readonly string[]).includes(format)) {
     return JSON.stringify(value) + '\n'
   }
   throw new Error(

--- a/packages/client-common/src/index.ts
+++ b/packages/client-common/src/index.ts
@@ -28,6 +28,12 @@ export type {
   StreamableDataFormat,
   StreamableJSONDataFormat,
   SingleDocumentJSONFormat,
+  SupportedJSONFormats,
+  SupportedRawFormats,
+  StreamableFormats,
+  StreamableJSONFormats,
+  SingleDocumentJSONFormats,
+  RecordsJSONFormats,
 } from './data_formatter'
 export { ClickHouseError } from './error'
 export {

--- a/packages/client-common/src/version.ts
+++ b/packages/client-common/src/version.ts
@@ -1,1 +1,1 @@
-export default '1.2.0'
+export default '1.2.1'

--- a/packages/client-node/src/index.ts
+++ b/packages/client-node/src/index.ts
@@ -39,4 +39,10 @@ export {
   ClickHouseError,
   ClickHouseLogLevel,
   SettingsMap,
+  SupportedJSONFormats,
+  SupportedRawFormats,
+  StreamableFormats,
+  StreamableJSONFormats,
+  SingleDocumentJSONFormats,
+  RecordsJSONFormats,
 } from '@clickhouse/client-common'

--- a/packages/client-node/src/version.ts
+++ b/packages/client-node/src/version.ts
@@ -1,1 +1,1 @@
-export default '1.2.0'
+export default '1.2.1'

--- a/packages/client-web/src/index.ts
+++ b/packages/client-web/src/index.ts
@@ -39,4 +39,10 @@ export {
   ClickHouseError,
   ClickHouseLogLevel,
   SettingsMap,
+  SupportedJSONFormats,
+  SupportedRawFormats,
+  StreamableFormats,
+  StreamableJSONFormats,
+  SingleDocumentJSONFormats,
+  RecordsJSONFormats,
 } from '@clickhouse/client-common'

--- a/packages/client-web/src/version.ts
+++ b/packages/client-web/src/version.ts
@@ -1,1 +1,1 @@
-export default '1.2.0'
+export default '1.2.1'


### PR DESCRIPTION
## Summary

Re-export supported formats literals in the Node.js/Web packages for convenience. Previously, only the inferred types were exported.
