### PR TITLE
An optional `values` parameter in the `exec` method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 1.4.0 (Node.js)
+
+## New features
+
+- (Node.js only) The `exec` method now accepts an optional `values` parameter, which allows you to pass the request body as a `Stream.Readable`. This can be useful in case of custom insert streaming with arbitrary ClickHouse data formats (which might not be explicitly supported and allowed by the client in the `insert` method yet). NB: in this case, you are expected to serialize the data in the stream in the required input format yourself.
+
 # 1.3.0 (Common, Node.js, Web)
 
 ## New features

--- a/packages/client-common/src/client.ts
+++ b/packages/client-common/src/client.ts
@@ -61,9 +61,16 @@ export type QueryResult<Stream, Format extends DataFormat> =
     ? BaseResultSet<Stream, unknown>
     : BaseResultSet<Stream, Format>
 
-export interface ExecParams extends BaseQueryParams {
-  /** Statement to execute. */
+export type ExecParams = BaseQueryParams & {
+  /** Statement to execute. By default, the query will be sent in the request body;
+   *  If {@link ExecParamsWithValues.values} are defined, the query is sent as a request parameter,
+   *  and the values are sent in the request body instead. */
   query: string
+}
+export type ExecParamsWithValues<Stream> = ExecParams & {
+  /** If you have a custom INSERT statement to run with `exec`,
+   *  the data from this stream will be inserted. */
+  values: Stream
 }
 
 export type CommandParams = ExecParams
@@ -214,10 +221,14 @@ export class ClickHouseClient<Stream = unknown> {
    * but format clause is not applicable. The caller of this method is expected to consume the stream,
    * otherwise, the request will eventually be timed out.
    */
-  async exec(params: ExecParams): Promise<ExecResult<Stream>> {
+  async exec(
+    params: ExecParams | ExecParamsWithValues<Stream>,
+  ): Promise<ExecResult<Stream>> {
     const query = removeTrailingSemi(params.query.trim())
+    const values = 'values' in params ? params.values : undefined
     return await this.connection.exec({
       query,
+      values,
       ...this.withClientQueryParams(params),
     })
   }

--- a/packages/client-common/src/client.ts
+++ b/packages/client-common/src/client.ts
@@ -62,14 +62,19 @@ export type QueryResult<Stream, Format extends DataFormat> =
     : BaseResultSet<Stream, Format>
 
 export type ExecParams = BaseQueryParams & {
-  /** Statement to execute. By default, the query will be sent in the request body;
+  /** Statement to execute (including the FORMAT clause). By default, the query will be sent in the request body;
    *  If {@link ExecParamsWithValues.values} are defined, the query is sent as a request parameter,
    *  and the values are sent in the request body instead. */
   query: string
 }
 export type ExecParamsWithValues<Stream> = ExecParams & {
   /** If you have a custom INSERT statement to run with `exec`,
-   *  the data from this stream will be inserted. */
+   *  the data from this stream will be inserted.
+   *
+   *  NB: the data in the stream is expected to be serialized accordingly to the FORMAT clause
+   *  used in {@link ExecParams.query} in this case.
+   *
+   *  @see https://clickhouse.com/docs/en/interfaces/formats */
   values: Stream
 }
 

--- a/packages/client-common/src/connection.ts
+++ b/packages/client-common/src/connection.ts
@@ -39,6 +39,10 @@ export interface ConnInsertParams<Stream> extends ConnBaseQueryParams {
   values: string | Stream
 }
 
+export interface ConnExecParams<Stream> extends ConnBaseQueryParams {
+  values?: Stream
+}
+
 export interface ConnBaseResult extends WithResponseHeaders {
   query_id: string
 }
@@ -66,6 +70,6 @@ export interface Connection<Stream> {
   close(): Promise<void>
   query(params: ConnBaseQueryParams): Promise<ConnQueryResult<Stream>>
   insert(params: ConnInsertParams<Stream>): Promise<ConnInsertResult>
-  exec(params: ConnBaseQueryParams): Promise<ConnExecResult<Stream>>
+  exec(params: ConnExecParams<Stream>): Promise<ConnExecResult<Stream>>
   command(params: ConnBaseQueryParams): Promise<ConnCommandResult>
 }

--- a/packages/client-common/src/index.ts
+++ b/packages/client-common/src/index.ts
@@ -93,6 +93,7 @@ export type {
   Connection,
   ConnectionParams,
   ConnInsertResult,
+  ConnExecParams,
   ConnExecResult,
   ConnQueryResult,
   ConnBaseQueryParams,

--- a/packages/client-common/src/version.ts
+++ b/packages/client-common/src/version.ts
@@ -1,1 +1,1 @@
-export default '1.3.0'
+export default '1.4.0'

--- a/packages/client-node/__tests__/integration/node_exec.test.ts
+++ b/packages/client-node/__tests__/integration/node_exec.test.ts
@@ -6,7 +6,7 @@ import Stream from 'stream'
 import { getAsText } from '../../src/utils'
 import { drainStream, ResultSet } from '../../src'
 
-fdescribe('[Node.js] exec', () => {
+describe('[Node.js] exec', () => {
   let client: ClickHouseClient<Stream.Readable>
   beforeEach(() => {
     client = createTestClient()

--- a/packages/client-node/src/connection/stream.ts
+++ b/packages/client-node/src/connection/stream.ts
@@ -1,6 +1,8 @@
 import type Stream from 'stream'
 
-/** See https://github.com/ClickHouse/clickhouse-js/pull/203 */
+/** Drains the response stream, as calling `destroy` on a {@link Stream.Readable} response stream
+ *  will result in closing the underlying socket, and negate the KeepAlive feature benefits.
+ *  See https://github.com/ClickHouse/clickhouse-js/pull/203 */
 export async function drainStream(stream: Stream.Readable): Promise<void> {
   return new Promise((resolve, reject) => {
     function dropData() {

--- a/packages/client-node/src/index.ts
+++ b/packages/client-node/src/index.ts
@@ -5,6 +5,7 @@ export type {
 export { createClient } from './client'
 export { type NodeClickHouseClientConfigOptions as ClickHouseClientConfigOptions } from './config'
 export { ResultSet, type StreamReadable } from './result_set'
+export { drainStream } from './connection/stream'
 
 /** Re-export @clickhouse/client-common types */
 export {

--- a/packages/client-node/src/version.ts
+++ b/packages/client-node/src/version.ts
@@ -1,1 +1,1 @@
-export default '1.3.0'
+export default '1.4.0'

--- a/packages/client-web/src/client.ts
+++ b/packages/client-web/src/client.ts
@@ -1,5 +1,7 @@
 import type {
   DataFormat,
+  ExecParams,
+  ExecResult,
   InputJSON,
   InputJSONObjectEachRow,
   InsertParams,
@@ -20,7 +22,10 @@ export type QueryResult<Format extends DataFormat> =
     ? ResultSet<unknown>
     : ResultSet<Format>
 
-export type WebClickHouseClient = Omit<WebClickHouseClientImpl, 'insert'> & {
+export type WebClickHouseClient = Omit<
+  WebClickHouseClientImpl,
+  'insert' | 'exec'
+> & {
   /** See {@link ClickHouseClient.insert}.
    *
    *  ReadableStream is removed from possible insert values
@@ -30,6 +35,10 @@ export type WebClickHouseClient = Omit<WebClickHouseClientImpl, 'insert'> & {
       values: ReadonlyArray<T> | InputJSON<T> | InputJSONObjectEachRow<T>
     },
   ): Promise<InsertResult>
+  /** See {@link ClickHouseClient.exec}.
+   *
+   *  Custom values are currently not supported in the web versions. */
+  exec(params: ExecParams): Promise<ExecResult<ReadableStream>>
 }
 
 class WebClickHouseClientImpl extends ClickHouseClient<ReadableStream> {

--- a/packages/client-web/src/version.ts
+++ b/packages/client-web/src/version.ts
@@ -1,1 +1,1 @@
-export default '1.3.0'
+export default '1.4.0'


### PR DESCRIPTION
## Summary

The `exec` method now accepts an optional `values` parameter, which allows you to pass the request body as a `Stream.Readable`. This can be useful in case of custom insert streaming with arbitrary ClickHouse data formats (which might not be explicitly supported and allowed by the client in the `insert` method yet). 

A very minimal example with CSV (from the tests, it does not make sense as CSV is supported via the normal `insert`, just an illustration):

```ts
const stream = Stream.Readable.from(['42,foobar,"[1,2]"'], {
  objectMode: false,
})
const execResult = await client.exec({
  query: `INSERT INTO ${tableName} FORMAT CSV`,
  values: stream,
})
// the result stream contains nothing useful for an insert 
// and should be immediately drained to release the socket
await drainStream(execResult.stream)

const rs = await client.query({
  query: `SELECT * FROM ${tableName}`,
  format: 'JSONEachRow',
})
expect(await rs.json()).toEqual([
  {
    id: '42',
    name: 'foobar',
    sku: [1, 2],
  },
])
```


## Checklist
- [x] Unit and integration tests covering the common scenarios were added
- [x] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
