### PR TITLE
Export NodeClickHouseClient and WebClickHouseClient as value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 1.5.0 (Node.js, Web)
+
+## New features
+
+- `ClickHouseClient` is now exported as a value from packages, allowing to a better integration in dependency injection frameworks which rely on IoC.
+
 # 1.4.0 (Node.js)
 
 ## New features

--- a/packages/client-node/src/index.ts
+++ b/packages/client-node/src/index.ts
@@ -1,6 +1,6 @@
-export type {
+export {
   NodeClickHouseClient as ClickHouseClient,
-  QueryResult,
+  type QueryResult,
 } from './client'
 export { createClient } from './client'
 export { type NodeClickHouseClientConfigOptions as ClickHouseClientConfigOptions } from './config'

--- a/packages/client-web/src/index.ts
+++ b/packages/client-web/src/index.ts
@@ -1,6 +1,6 @@
-export type {
+export {
   WebClickHouseClient as ClickHouseClient,
-  QueryResult,
+  type QueryResult,
 } from './client'
 export { createClient } from './client'
 export { type WebClickHouseClientConfigOptions as ClickHouseClientConfigOptions } from './config'


### PR DESCRIPTION
## Summary
This PR exposes the `NodeClickHouseClient` and `WebClickHouseClient` as values from their respective packages `@clickhouse/client `and `@clickhouse/client-web`. This will allow better integrations with dependency injection frameworks like Nest.js or [tsyringe](https://github.com/microsoft/tsyringe). More details are available on #292.

This PR closes #292.

## Checklist
Delete items not relevant to your PR:
- [X] A human-readable description of the changes was provided to include in CHANGELOG

@maintainers: I added a CHANGELOG entry but I am a bit unsure of the version + the CHANGELOG message. Feel free to change the version number or the message if necessary.
