### PR TITLE
Adjust the tests that rely on the old `Object('json')` data type

### DIFF
--- a/examples/insert_ephemeral_columns.ts
+++ b/examples/insert_ephemeral_columns.ts
@@ -9,9 +9,9 @@ void (async () => {
     query: `
       CREATE OR REPLACE TABLE ${tableName}
       (
-        id          UInt64,
-        message     String DEFAULT message_raw,
-        message_raw String EPHEMERAL
+        id              UInt64,
+        message         String DEFAULT message_default,
+        message_default String EPHEMERAL
       )
       ENGINE MergeTree()
       ORDER BY (id)
@@ -23,17 +23,17 @@ void (async () => {
     values: [
       {
         id: '42',
-        message_raw: 'foo',
+        message_default: 'foo',
       },
       {
         id: '144',
-        message_raw: 'bar',
+        message_default: 'bar',
       },
     ],
     format: 'JSONEachRow',
     // The name of the ephemeral column has to be specified here
     // to trigger the default values logic for the rest of the columns
-    columns: ['message_raw'],
+    columns: ['id', 'message_default'],
   })
 
   const rows = await client.query({

--- a/examples/insert_ephemeral_columns.ts
+++ b/examples/insert_ephemeral_columns.ts
@@ -1,26 +1,20 @@
 import { createClient } from '@clickhouse/client' // or '@clickhouse/client-web'
 
 // Ephemeral columns documentation: https://clickhouse.com/docs/en/sql-reference/statements/create/table#ephemeral
-// This example is inspired by https://github.com/ClickHouse/clickhouse-js/issues/217
 void (async () => {
   const tableName = 'insert_ephemeral_columns'
-  const client = createClient({
-    clickhouse_settings: {
-      allow_experimental_object_type: 1, // allows JSON type usage
-    },
-  })
+  const client = createClient({})
 
   await client.command({
     query: `
       CREATE OR REPLACE TABLE ${tableName}
       (
-        event_type  LowCardinality(String) DEFAULT JSONExtractString(message_raw, 'type'),
-        repo_name   LowCardinality(String) DEFAULT JSONExtractString(message_raw, 'repo', 'name'),
-        message     JSON                   DEFAULT message_raw,
-        message_raw String                 EPHEMERAL
+        id          UInt64,
+        message     String DEFAULT message_raw,
+        message_raw String EPHEMERAL
       )
       ENGINE MergeTree()
-      ORDER BY (event_type, repo_name)
+      ORDER BY (id)
     `,
   })
 
@@ -28,20 +22,12 @@ void (async () => {
     table: tableName,
     values: [
       {
-        message_raw: {
-          type: 'MyEventType',
-          repo: {
-            name: 'foo',
-          },
-        },
+        id: '42',
+        message_raw: 'foo',
       },
       {
-        message_raw: {
-          type: 'SomeOtherType',
-          repo: {
-            name: 'bar',
-          },
-        },
+        id: '144',
+        message_raw: 'bar',
       },
     ],
     format: 'JSONEachRow',
@@ -51,10 +37,11 @@ void (async () => {
   })
 
   const rows = await client.query({
-    query: `SELECT * FROM ${tableName}`,
-    format: 'JSONCompactEachRowWithNames',
+    query: `SELECT *
+            FROM ${tableName}`,
+    format: 'JSONEachRow',
   })
 
-  console.info(await rows.text())
+  console.info(await rows.json())
   await client.close()
 })()

--- a/packages/client-common/__tests__/integration/data_types.test.ts
+++ b/packages/client-common/__tests__/integration/data_types.test.ts
@@ -4,7 +4,7 @@ import type {
 } from '@clickhouse/client-common'
 import { randomUUID } from '@test/utils/guid'
 import { createTableWithFields } from '../fixtures/table_with_fields'
-import { createTestClient, getRandomInt, TestEnv, whenOnEnv } from '../utils'
+import { createTestClient, getRandomInt } from '../utils'
 
 describe('data types', () => {
   let client: ClickHouseClient
@@ -503,25 +503,6 @@ describe('data types', () => {
     )
     await insertAndAssert(table, values)
   })
-
-  // JSON cannot be used on a "modern" Cloud instance
-  whenOnEnv(TestEnv.LocalSingleNode, TestEnv.LocalCluster, TestEnv.Cloud).it(
-    'should work with JSON',
-    async () => {
-      const values = [
-        {
-          o: { a: 1, b: { c: 2, d: [1, 2, 3] } },
-        },
-        {
-          o: { a: 2, b: { c: 3, d: [4, 5, 6] } },
-        },
-      ]
-      const table = await createTableWithFields(client, 'o JSON', {
-        allow_experimental_object_type: 1,
-      })
-      await insertAndAssert(table, values)
-    },
-  )
 
   describe('Nested', () => {
     it('should work by default', async () => {

--- a/packages/client-common/__tests__/integration/data_types.test.ts
+++ b/packages/client-common/__tests__/integration/data_types.test.ts
@@ -4,7 +4,7 @@ import type {
 } from '@clickhouse/client-common'
 import { randomUUID } from '@test/utils/guid'
 import { createTableWithFields } from '../fixtures/table_with_fields'
-import { createTestClient, getRandomInt } from '../utils'
+import { createTestClient, getRandomInt, TestEnv, whenOnEnv } from '../utils'
 
 describe('data types', () => {
   let client: ClickHouseClient
@@ -503,6 +503,25 @@ describe('data types', () => {
     )
     await insertAndAssert(table, values)
   })
+
+  // JSON cannot be used on a "modern" Cloud instance
+  whenOnEnv(TestEnv.LocalSingleNode, TestEnv.LocalCluster, TestEnv.Cloud).it(
+    'should work with JSON',
+    async () => {
+      const values = [
+        {
+          o: { a: 1, b: { c: 2, d: [1, 2, 3] } },
+        },
+        {
+          o: { a: 2, b: { c: 3, d: [4, 5, 6] } },
+        },
+      ]
+      const table = await createTableWithFields(client, `o Object('json')`, {
+        allow_experimental_object_type: 1,
+      })
+      await insertAndAssert(table, values)
+    },
+  )
 
   describe('Nested', () => {
     it('should work by default', async () => {


### PR DESCRIPTION
## Summary
Remove/rewrite the tests that rely on the old experimental JSON data type since this is failing on the latest CH master. 
The ephemeral columns example is simplified.