### PR TITLE
Add minimal Variant/Dynamic/JSON examples and tests using JSONEachRow format

### DIFF
--- a/.docker/clickhouse/single_node_tls/Dockerfile
+++ b/.docker/clickhouse/single_node_tls/Dockerfile
@@ -1,4 +1,4 @@
-FROM clickhouse/clickhouse-server:24.3-alpine
+FROM clickhouse/clickhouse-server:24.8-alpine
 COPY .docker/clickhouse/single_node_tls/certificates /etc/clickhouse-server/certs
 RUN chown clickhouse:clickhouse -R /etc/clickhouse-server/certs \
     && chmod 600 /etc/clickhouse-server/certs/* \

--- a/docker-compose.cluster.yml
+++ b/docker-compose.cluster.yml
@@ -2,7 +2,7 @@ version: '2.3'
 
 services:
   clickhouse1:
-    image: 'clickhouse/clickhouse-server:${CLICKHOUSE_VERSION-24.3-alpine}'
+    image: 'clickhouse/clickhouse-server:${CLICKHOUSE_VERSION-24.8-alpine}'
     ulimits:
       nofile:
         soft: 262144
@@ -19,7 +19,7 @@ services:
       - './.docker/clickhouse/users.xml:/etc/clickhouse-server/users.xml'
 
   clickhouse2:
-    image: 'clickhouse/clickhouse-server:${CLICKHOUSE_VERSION-24.3-alpine}'
+    image: 'clickhouse/clickhouse-server:${CLICKHOUSE_VERSION-24.8-alpine}'
     ulimits:
       nofile:
         soft: 262144

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.8'
 services:
   clickhouse:
-    image: 'clickhouse/clickhouse-server:${CLICKHOUSE_VERSION-24.3-alpine}'
+    image: 'clickhouse/clickhouse-server:${CLICKHOUSE_VERSION-24.8-alpine}'
     container_name: 'clickhouse-js-clickhouse-server'
     ports:
       - '8123:8123'

--- a/examples/README.md
+++ b/examples/README.md
@@ -58,6 +58,10 @@ If something is missing, or you found a mistake in one of these examples, please
 - [select_streaming_json_each_row_for_await.ts](node/select_streaming_json_each_row_for_await.ts) - (Node.js only) similar to [select_streaming_json_each_row.ts](node/select_streaming_json_each_row.ts), but using the `for await` loop syntax.
 - [select_streaming_text_line_by_line.ts](node/select_streaming_text_line_by_line.ts) - (Node.js only) streaming text formats from ClickHouse and processing it line by line. In this example, CSV format is used.
 
+#### Data types
+
+- [dynamic_variant_json.ts](./dynamic_variant_json.ts) - using experimental [Dynamic](https://clickhouse.com/docs/en/sql-reference/data-types/dynamic)/[Variant](https://clickhouse.com/docs/en/sql-reference/data-types/variant)/[JSON](https://clickhouse.com/docs/en/sql-reference/data-types/newjson) data types with [JSONEachRow](https://clickhouse.com/docs/en/interfaces/formats#jsoneachrow) format.
+
 #### Special cases
 
 - [default_format_setting.ts](default_format_setting.ts) - sending queries using `exec` method without a `FORMAT` clause; the default format will be set from the client settings.

--- a/examples/dynamic_variant_json.ts
+++ b/examples/dynamic_variant_json.ts
@@ -1,0 +1,68 @@
+import { createClient } from '@clickhouse/client' // or '@clickhouse/client-web'
+
+void (async () => {
+  const tableName = `chjs_dynamic_variant_json`
+  const client = createClient({
+    clickhouse_settings: {
+      // Since ClickHouse 24.1
+      allow_experimental_variant_type: 1,
+      // Since ClickHouse 24.5
+      allow_experimental_dynamic_type: 1,
+      // Since ClickHouse 24.8
+      allow_experimental_json_type: 1,
+    },
+  })
+  await client.command({
+    query: `
+      CREATE OR REPLACE TABLE ${tableName}
+      (
+        id              UInt64,
+        var             Variant(Int64, String),
+        dynamic         Dynamic,
+        json            JSON
+      )
+      ENGINE MergeTree
+      ORDER BY id
+    `,
+  })
+  // Sample representation in JSONEachRow format
+  const values = [
+    {
+      id: 1,
+      var: 42,
+      dynamic: 'foo',
+      json: {
+        foo: 'x',
+      },
+    },
+    {
+      id: 2,
+      var: 'str',
+      // defaults to Int64; will be represented as a string in JSON* family formats
+      // this behavior can be changed with `output_format_json_quote_64bit_integers` setting (default is 1).
+      // see https://clickhouse.com/docs/en/operations/settings/formats#output_format_json_quote_64bit_integers
+      dynamic: 144,
+      json: {
+        bar: 10,
+      },
+    },
+  ]
+  await client.insert({
+    table: tableName,
+    format: 'JSONEachRow',
+    values,
+  })
+  const rs = await client.query({
+    query: `
+      SELECT *,
+             variantType(var),
+             dynamicType(dynamic),
+             dynamicType(json.foo),
+             dynamicType(json.bar)
+      FROM ${tableName}
+    `,
+    format: 'JSONEachRow',
+  })
+  console.log(await rs.json())
+  await client.close()
+})()

--- a/packages/client-common/__tests__/integration/data_types.test.ts
+++ b/packages/client-common/__tests__/integration/data_types.test.ts
@@ -551,7 +551,7 @@ describe('data types', () => {
   )
 
   // New experimental Dynamic type
-  // https://clickhouse.com/docs/en/sql-reference/data-types/variant
+  // https://clickhouse.com/docs/en/sql-reference/data-types/dynamic
   whenOnEnv(TestEnv.LocalSingleNode, TestEnv.LocalCluster).it(
     'should work with Dynamic',
     async () => {


### PR DESCRIPTION
## Summary

* Bump CH in Docker 24.3 -> 24.8
* Add minimal Variant/Dynamic/JSON examples and tests using the JSONEachRow format.

The website docs will be updated accordingly after this is merged.

## Checklist
- [x] Unit and integration tests covering the common scenarios were added
