### PR TITLE
Fix head version tests, add `ClickHouseSummary. real_time_microseconds`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Unreleased
+
+## New features
+
+- Added optional `real_time_microseconds` field to the `ClickHouseSummary` interface (see https://github.com/ClickHouse/ClickHouse/pull/69032)
+
 # 1.5.0 (Node.js)
 
 ## New features

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3.8'
+#version: '3.8'
 services:
   clickhouse:
     image: 'clickhouse/clickhouse-server:${CLICKHOUSE_VERSION-24.8-alpine}'

--- a/packages/client-common/src/clickhouse_types.ts
+++ b/packages/client-common/src/clickhouse_types.ts
@@ -27,6 +27,8 @@ export interface ClickHouseSummary {
   result_rows: string
   result_bytes: string
   elapsed_ns: string
+  /** Available only after ClickHouse 24.9 */
+  real_time_microseconds?: string
 }
 
 export type ResponseHeaders = Record<string, string | string[] | undefined>

--- a/packages/client-node/__tests__/integration/node_summary.test.ts
+++ b/packages/client-node/__tests__/integration/node_summary.test.ts
@@ -30,30 +30,34 @@ whenOnEnv(
       values: jsonValues,
       format: 'JSONEachRow',
     })
-    expect(insertSummary).toEqual({
-      read_rows: '5',
-      read_bytes: jasmine.any(String),
-      written_rows: '5',
-      written_bytes: jasmine.any(String),
-      total_rows_to_read: '0',
-      result_rows: '5',
-      result_bytes: jasmine.any(String),
-      elapsed_ns: jasmine.any(String),
-    })
+    expect(insertSummary).toEqual(
+      jasmine.objectContaining({
+        read_rows: '5',
+        read_bytes: jasmine.any(String),
+        written_rows: '5',
+        written_bytes: jasmine.any(String),
+        total_rows_to_read: '0',
+        result_rows: '5',
+        result_bytes: jasmine.any(String),
+        elapsed_ns: jasmine.any(String),
+      }),
+    )
 
     const { summary: execSummary } = await client.exec({
       query: `INSERT INTO ${tableName} SELECT * FROM ${tableName}`,
     })
-    expect(execSummary).toEqual({
-      read_rows: '5',
-      read_bytes: jasmine.any(String),
-      written_rows: '5',
-      written_bytes: jasmine.any(String),
-      total_rows_to_read: '5',
-      result_rows: '5',
-      result_bytes: jasmine.any(String),
-      elapsed_ns: jasmine.any(String),
-    })
+    expect(execSummary).toEqual(
+      jasmine.objectContaining({
+        read_rows: '5',
+        read_bytes: jasmine.any(String),
+        written_rows: '5',
+        written_bytes: jasmine.any(String),
+        total_rows_to_read: '5',
+        result_rows: '5',
+        result_bytes: jasmine.any(String),
+        elapsed_ns: jasmine.any(String),
+      }),
+    )
   })
 
   it('should provide summary for command', async () => {
@@ -63,15 +67,17 @@ whenOnEnv(
         wait_end_of_query: 1,
       },
     })
-    expect(summary).toEqual({
-      read_rows: '2',
-      read_bytes: jasmine.any(String),
-      written_rows: '2',
-      written_bytes: jasmine.any(String),
-      total_rows_to_read: '0',
-      result_rows: '2',
-      result_bytes: jasmine.any(String),
-      elapsed_ns: jasmine.any(String),
-    })
+    expect(summary).toEqual(
+      jasmine.objectContaining({
+        read_rows: '2',
+        read_bytes: jasmine.any(String),
+        written_rows: '2',
+        written_bytes: jasmine.any(String),
+        total_rows_to_read: '0',
+        result_rows: '2',
+        result_bytes: jasmine.any(String),
+        elapsed_ns: jasmine.any(String),
+      }),
+    )
   })
 })

--- a/packages/client-node/__tests__/integration/node_summary.test.ts
+++ b/packages/client-node/__tests__/integration/node_summary.test.ts
@@ -42,9 +42,12 @@ whenOnEnv(
         elapsed_ns: jasmine.any(String),
       }),
     )
+    assertRealTimeMicroseconds(insertSummary)
 
     const { summary: execSummary } = await client.exec({
-      query: `INSERT INTO ${tableName} SELECT * FROM ${tableName}`,
+      query: `INSERT INTO ${tableName}
+              SELECT *
+              FROM ${tableName}`,
     })
     expect(execSummary).toEqual(
       jasmine.objectContaining({
@@ -58,11 +61,14 @@ whenOnEnv(
         elapsed_ns: jasmine.any(String),
       }),
     )
+    assertRealTimeMicroseconds(execSummary)
   })
 
   it('should provide summary for command', async () => {
     const { summary } = await client.command({
-      query: `INSERT INTO ${tableName} VALUES (144, 'Hello', [2, 4]), (255, 'World', [3, 5])`,
+      query: `INSERT INTO ${tableName}
+              VALUES (144, 'Hello', [2, 4]),
+                     (255, 'World', [3, 5])`,
       clickhouse_settings: {
         wait_end_of_query: 1,
       },
@@ -79,5 +85,14 @@ whenOnEnv(
         elapsed_ns: jasmine.any(String),
       }),
     )
+    assertRealTimeMicroseconds(summary)
   })
+
+  function assertRealTimeMicroseconds(summary: any) {
+    // FIXME: remove this condition after 24.9 is released
+    if (process.env['CLICKHOUSE_VERSION'] === 'head') {
+      expect(summary.real_time_microseconds).toBeDefined()
+      expect(summary.real_time_microseconds).toMatch(/^\d+$/)
+    }
+  }
 })


### PR DESCRIPTION
## Summary

* Add optional `real_time_microseconds` to `ClickHouseSummary`
* Fix summary assertions with `head` CH version after https://github.com/ClickHouse/ClickHouse/pull/69032

## Checklist
- [x] Unit and integration tests covering the common scenarios were added
- [x] A human-readable description of the changes was provided to include in CHANGELOG
