### PR TITLE
Added missing crypto import

### DIFF
--- a/packages/client-web/src/connection/web_connection.ts
+++ b/packages/client-web/src/connection/web_connection.ts
@@ -18,6 +18,7 @@ import {
   withHttpSettings,
 } from '@clickhouse/client-common'
 import { getAsText } from '../utils'
+import crypto from 'crypto'
 
 type WebInsertParams<T> = Omit<
   ConnInsertParams<ReadableStream<T>>,


### PR DESCRIPTION
## Summary

Added missing "crypto" module import so that it won't crash with Deno because of undefined randomUUID function.

Closes #340.
