### PR TITLE
Add read-only users cleanup to the tests

### DIFF
--- a/packages/client-web/__tests__/integration/web_abort_request.test.ts
+++ b/packages/client-web/__tests__/integration/web_abort_request.test.ts
@@ -1,11 +1,12 @@
-import type { ClickHouseClient, Row } from '@clickhouse/client-common'
+import type { Row } from '@clickhouse/client-common'
 import { createTestClient } from '@test/utils'
+import type { WebClickHouseClient } from '../../src/client'
 
 describe('[Web] abort request', () => {
-  let client: ClickHouseClient<ReadableStream>
+  let client: WebClickHouseClient
 
   beforeEach(() => {
-    client = createTestClient()
+    client = createTestClient() as unknown as WebClickHouseClient
   })
 
   afterEach(async () => {
@@ -65,10 +66,15 @@ describe('[Web] abort request', () => {
   })
 
   it('cancels a select query while reading response by closing response stream', async () => {
+    let rowCount = 0
     const selectPromise = client
       .query({
-        query: 'SELECT * from system.numbers LIMIT 100000',
+        query: 'SELECT sleepEachRow(0.01), number FROM system.numbers LIMIT 3',
         format: 'JSONCompactEachRow',
+        clickhouse_settings: {
+          // low block size to force streaming 1 row at a time
+          max_block_size: '1',
+        },
       })
       .then(async function (rs) {
         const reader = rs.stream().getReader()
@@ -76,12 +82,11 @@ describe('[Web] abort request', () => {
           const { done, value: rows } = await reader.read()
           if (done) break
           for (const row of rows as Row[]) {
-            const [number] = row.json<[string]>()
-            // abort when reach number 3
-            if (number === '3') {
-              await reader.releaseLock()
-              await rs.close()
+            row.json()
+            if (rowCount >= 1) {
+              await rs.stream().cancel()
             }
+            rowCount++
           }
         }
       })

--- a/packages/client-web/__tests__/integration/web_abort_request.test.ts
+++ b/packages/client-web/__tests__/integration/web_abort_request.test.ts
@@ -2,7 +2,7 @@ import type { Row } from '@clickhouse/client-common'
 import { createTestClient } from '@test/utils'
 import type { WebClickHouseClient } from '../../src/client'
 
-describe('[Web] abort request', () => {
+fdescribe('[Web] abort request', () => {
   let client: WebClickHouseClient
 
   beforeEach(() => {
@@ -35,7 +35,7 @@ describe('[Web] abort request', () => {
     let rowCount = 0
     const selectPromise = client
       .query({
-        query: 'SELECT sleepEachRow(0.01), number FROM system.numbers LIMIT 3',
+        query: 'SELECT number FROM system.numbers LIMIT 1000',
         format: 'JSONCompactEachRow',
         abort_signal: controller.signal,
         clickhouse_settings: {
@@ -69,7 +69,7 @@ describe('[Web] abort request', () => {
     let rowCount = 0
     const selectPromise = client
       .query({
-        query: 'SELECT sleepEachRow(0.01), number FROM system.numbers LIMIT 3',
+        query: 'SELECT number FROM system.numbers LIMIT 3',
         format: 'JSONCompactEachRow',
         clickhouse_settings: {
           // low block size to force streaming 1 row at a time


### PR DESCRIPTION
## Summary
Adds a cleanup so that it does not create too many dangling read-only users with the Cloud tests. 
Fixes a few flaky web tests.