### PR TITLE
Fix a flaky web test

### DIFF
--- a/packages/client-web/__tests__/integration/web_abort_request.test.ts
+++ b/packages/client-web/__tests__/integration/web_abort_request.test.ts
@@ -2,7 +2,7 @@ import type { Row } from '@clickhouse/client-common'
 import { createTestClient } from '@test/utils'
 import type { WebClickHouseClient } from '../../src/client'
 
-fdescribe('[Web] abort request', () => {
+describe('[Web] abort request', () => {
   let client: WebClickHouseClient
 
   beforeEach(() => {
@@ -35,7 +35,7 @@ fdescribe('[Web] abort request', () => {
     let rowCount = 0
     const selectPromise = client
       .query({
-        query: 'SELECT number FROM system.numbers LIMIT 1000',
+        query: 'SELECT number FROM system.numbers LIMIT 10000',
         format: 'JSONCompactEachRow',
         abort_signal: controller.signal,
         clickhouse_settings: {


### PR DESCRIPTION
Increase the limit so that the streaming is triggered reliably when the tests are run on a local cluster.