### PR TITLE
Choose proper HTTP(S) request implementation based on the agent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 1.8.1 (Node.js)
+
+## Bug fixes
+
+- When a custom HTTP agent is used, the HTTP or HTTPS request implementation is now correctly chosen based on the HTTP Agent instance type. ([#352](https://github.com/ClickHouse/clickhouse-js/issues/352))
+
 # 1.8.0 (Common, Node.js, Web)
 
 ## New features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Bug fixes
 
-- When a custom HTTP agent is used, the HTTP or HTTPS request implementation is now correctly chosen based on the HTTP Agent instance type. ([#352](https://github.com/ClickHouse/clickhouse-js/issues/352))
+- When a custom HTTP agent is used, the HTTP or HTTPS request implementation is now correctly chosen based on the URL protocol. ([#352](https://github.com/ClickHouse/clickhouse-js/issues/352))
 
 # 1.8.0 (Common, Node.js, Web)
 

--- a/packages/client-common/src/version.ts
+++ b/packages/client-common/src/version.ts
@@ -1,1 +1,1 @@
-export default '1.8.0'
+export default '1.8.1'

--- a/packages/client-node/__tests__/tls/tls.test.ts
+++ b/packages/client-node/__tests__/tls/tls.test.ts
@@ -5,6 +5,8 @@ import Http from 'http'
 import https from 'node:https'
 import type Stream from 'stream'
 import { createClient } from '../../src'
+import Https from 'https'
+import http from 'http'
 
 describe('[Node.js] TLS connection', () => {
   let client: ClickHouseClient<Stream.Readable>
@@ -138,13 +140,9 @@ describe('[Node.js] TLS connection', () => {
       expect(await resultSet.text()).toEqual('0\n1\n2\n')
     })
 
-    describe('Custom HTTPS agent', () => {
-      let httpRequestStub: jasmine.Spy<typeof Http.request>
-      beforeEach(() => {
-        httpRequestStub = spyOn(Http, 'request').and.callThrough()
-      })
-
+    fdescribe('Custom HTTPS agent', () => {
       it('should work with a custom HTTPS agent', async () => {
+        const httpsRequestStub = spyOn(Https, 'request').and.callThrough()
         const agent = new https.Agent({
           maxFreeSockets: 5,
           ca: ca_cert,
@@ -157,6 +155,26 @@ describe('[Node.js] TLS connection', () => {
             'X-ClickHouse-Key': '',
           },
           set_basic_auth_header: false,
+        })
+        const rs = await client.query({
+          query: 'SELECT 144 AS result',
+          format: 'JSONEachRow',
+        })
+        expect(await rs.json()).toEqual([{ result: 144 }])
+        expect(httpsRequestStub).toHaveBeenCalledTimes(1)
+        const callArgs = httpsRequestStub.calls.mostRecent().args
+        expect(callArgs[1].agent).toBe(agent)
+      })
+
+      // does not really belong to the TLS test; keep it here for consistency
+      it('should work with a custom HTTP agent', async () => {
+        const httpRequestStub = spyOn(Http, 'request').and.callThrough()
+        const agent = new http.Agent({
+          maxFreeSockets: 5,
+        })
+        const client = createClient({
+          url: 'http://localhost:8123',
+          http_agent: agent,
         })
         const rs = await client.query({
           query: 'SELECT 144 AS result',

--- a/packages/client-node/__tests__/tls/tls.test.ts
+++ b/packages/client-node/__tests__/tls/tls.test.ts
@@ -140,7 +140,7 @@ describe('[Node.js] TLS connection', () => {
       expect(await resultSet.text()).toEqual('0\n1\n2\n')
     })
 
-    fdescribe('Custom HTTPS agent', () => {
+    describe('Custom HTTPS agent', () => {
       it('should work with a custom HTTPS agent', async () => {
         const httpsRequestStub = spyOn(Https, 'request').and.callThrough()
         const agent = new https.Agent({

--- a/packages/client-node/src/connection/node_custom_agent_connection.ts
+++ b/packages/client-node/src/connection/node_custom_agent_connection.ts
@@ -1,12 +1,14 @@
-import { withCompressionHeaders } from '@clickhouse/client-common'
 import Http from 'http'
+import Https from 'https'
 import type {
   NodeConnectionParams,
   RequestParams,
 } from './node_base_connection'
 import { NodeBaseConnection } from './node_base_connection'
+import { withCompressionHeaders } from '@clickhouse/client-common'
 
 export class NodeCustomAgentConnection extends NodeBaseConnection {
+  private readonly httpRequestFn: typeof Http.request | typeof Https.request
   constructor(params: NodeConnectionParams) {
     if (!params.http_agent) {
       throw new Error(
@@ -14,6 +16,13 @@ export class NodeCustomAgentConnection extends NodeBaseConnection {
       )
     }
     super(params, params.http_agent)
+
+    // See https://github.com/ClickHouse/clickhouse-js/issues/352
+    if (params.http_agent instanceof Https.Agent) {
+      this.httpRequestFn = Https.request
+    } else {
+      this.httpRequestFn = Http.request
+    }
   }
 
   protected createClientRequest(params: RequestParams): Http.ClientRequest {
@@ -22,7 +31,7 @@ export class NodeCustomAgentConnection extends NodeBaseConnection {
       enable_request_compression: params.enable_request_compression,
       enable_response_compression: params.enable_response_compression,
     })
-    return Http.request(params.url, {
+    return this.httpRequestFn(params.url, {
       method: params.method,
       agent: this.agent,
       timeout: this.params.request_timeout,

--- a/packages/client-node/src/connection/node_custom_agent_connection.ts
+++ b/packages/client-node/src/connection/node_custom_agent_connection.ts
@@ -18,7 +18,7 @@ export class NodeCustomAgentConnection extends NodeBaseConnection {
     super(params, params.http_agent)
 
     // See https://github.com/ClickHouse/clickhouse-js/issues/352
-    if (params.http_agent instanceof Https.Agent) {
+    if (params.url.protocol.startsWith('https')) {
       this.httpRequestFn = Https.request
     } else {
       this.httpRequestFn = Http.request

--- a/packages/client-node/src/version.ts
+++ b/packages/client-node/src/version.ts
@@ -1,1 +1,1 @@
-export default '1.8.0'
+export default '1.8.1'

--- a/packages/client-web/src/version.ts
+++ b/packages/client-web/src/version.ts
@@ -1,1 +1,1 @@
-export default '1.8.0'
+export default '1.8.1'


### PR DESCRIPTION
## Summary

Closes #352 

Unfortunately, this is a little bit tricky to test.
