### PR TITLE
Improvements to the Tuple and Map parameter binding

### DIFF
--- a/packages/client-common/src/client.ts
+++ b/packages/client-common/src/client.ts
@@ -32,7 +32,7 @@ export interface BaseQueryParams {
    *  @default undefined (no override) */
   session_id?: string
   /** A specific list of roles to use for this query.
-   *  If it is not set, {@link BaseClickHouseClientConfigOptions.roles} will be used.
+   *  If it is not set, {@link BaseClickHouseClientConfigOptions.role} will be used.
    *  @default undefined (no override) */
   role?: string | Array<string>
   /** When defined, overrides the credentials from the {@link BaseClickHouseClientConfigOptions.username}

--- a/packages/client-common/src/data_formatter/format_query_params.ts
+++ b/packages/client-common/src/data_formatter/format_query_params.ts
@@ -1,3 +1,7 @@
+export class TupleParam {
+  constructor(public readonly values: any[]) {}
+}
+
 export function formatQueryParams(
   value: any,
   wrapStringInQuotes = false,
@@ -36,8 +40,7 @@ export function formatQueryParams(
   }
 
   if (Array.isArray(value)) {
-    const formatted = value.map((v) => formatQueryParams(v, true))
-    return `[${formatted.join(',')}]`
+    return `[${value.map((v) => formatQueryParams(v, true)).join(',')}]`
   }
 
   if (value instanceof Date) {
@@ -51,6 +54,21 @@ export function formatQueryParams(
       : `${unixTimestamp}.${milliseconds.toString().padStart(3, '0')}`
   }
 
+  if (value instanceof TupleParam) {
+    return `(${value.values.map((v) => formatQueryParams(v, true)).join(',')})`
+  }
+
+  if (value instanceof Map) {
+    const formatted: string[] = []
+    for (const [key, val] of value) {
+      formatted.push(
+        `${formatQueryParams(key, true)}:${formatQueryParams(val, true)}`,
+      )
+    }
+    return `{${formatted.join(',')}}`
+  }
+
+  // This is only useful for simple maps where the keys are strings
   if (typeof value === 'object') {
     const formatted: string[] = []
     for (const [key, val] of Object.entries(value)) {

--- a/packages/client-common/src/data_formatter/index.ts
+++ b/packages/client-common/src/data_formatter/index.ts
@@ -1,3 +1,3 @@
 export * from './formatter'
-export { formatQueryParams } from './format_query_params'
+export { TupleParam, formatQueryParams } from './format_query_params'
 export { formatQuerySettings } from './format_query_settings'

--- a/packages/client-common/src/index.ts
+++ b/packages/client-common/src/index.ts
@@ -36,6 +36,7 @@ export type {
   SingleDocumentJSONFormats,
   RecordsJSONFormats,
 } from './data_formatter'
+export { TupleParam } from './data_formatter'
 export { ClickHouseError } from './error'
 export {
   ClickHouseLogLevel,

--- a/packages/client-common/src/utils/url.ts
+++ b/packages/client-common/src/utils/url.ts
@@ -56,7 +56,8 @@ export function toSearchParams({
 
   if (query_params !== undefined) {
     for (const [key, value] of Object.entries(query_params)) {
-      params.set(`param_${key}`, formatQueryParams(value))
+      const formattedParam = formatQueryParams(value)
+      params.set(`param_${key}`, formattedParam)
     }
   }
 

--- a/packages/client-node/src/index.ts
+++ b/packages/client-node/src/index.ts
@@ -63,4 +63,5 @@ export {
   type ProgressRow,
   isProgressRow,
   type RowOrProgress,
+  TupleParam,
 } from '@clickhouse/client-common'

--- a/packages/client-web/src/index.ts
+++ b/packages/client-web/src/index.ts
@@ -62,4 +62,5 @@ export {
   type ProgressRow,
   isProgressRow,
   type RowOrProgress,
+  TupleParam,
 } from '@clickhouse/client-common'


### PR DESCRIPTION
## Summary

Closes #358 

- The client now exports a new wrapper class: `TupleParam`, as tuples need to be serialized as just strings like `('foo','bar')`; however, if it is provided like that in the current version, the single quotes will be escaped, which results in a query failure.

- Added a proper format for the JS `Map` type (it was missing previously), as specifying maps as just objects works only if the CH Map key is a String (cause the JS keys are always strings), and fails in case of Ints, etc.

## Checklist
- [x] Unit and integration tests covering the common scenarios were added
- [x] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
