### PR TITLE
Fix an uncaught exception during failure response decompression

### DIFF
--- a/packages/client-node/__tests__/integration/node_compression.test.ts
+++ b/packages/client-node/__tests__/integration/node_compression.test.ts
@@ -1,0 +1,81 @@
+import type { ClickHouseClient } from '@clickhouse/client-common'
+import { createTestClient } from '@test/utils'
+import http from 'http'
+import type Stream from 'stream'
+import type { NodeClickHouseClientConfigOptions } from '../../src/config'
+
+describe('[Node.js] Compression', () => {
+  const port = 18123
+
+  let client: ClickHouseClient<Stream.Readable>
+  let server: http.Server
+
+  describe('Malformed compression response', () => {
+    const logAndQuit = (err: Error | unknown, prefix: string) => {
+      console.error(prefix, err)
+      process.exit(1)
+    }
+    const uncaughtExceptionListener = (err: Error) =>
+      logAndQuit(err, 'uncaughtException:')
+    const unhandledRejectionListener = (err: unknown) =>
+      logAndQuit(err, 'unhandledRejection:')
+
+    beforeEach(async () => {
+      process.on('uncaughtException', uncaughtExceptionListener)
+      process.on('unhandledRejection', unhandledRejectionListener)
+      client = createTestClient({
+        url: `http://localhost:${port}`,
+        compression: {
+          response: true,
+        },
+      } as NodeClickHouseClientConfigOptions)
+    })
+    afterEach(async () => {
+      process.off('uncaughtException', uncaughtExceptionListener)
+      process.off('unhandledRejection', unhandledRejectionListener)
+      await client.close()
+      server.close()
+    })
+
+    it('should not propagate the exception to the global context if a failed response is malformed', async () => {
+      server = http.createServer(async (_req, res) => {
+        return makeResponse(res, 500)
+      })
+      server.listen(port)
+
+      // The request fails completely (and the error message cannot be decompressed)
+      await expectAsync(
+        client.query({
+          query: 'SELECT 1',
+          format: 'JSONEachRow',
+        }),
+      ).toBeRejectedWith(
+        jasmine.objectContaining({
+          code: 'Z_DATA_ERROR',
+        }),
+      )
+    })
+
+    it('should not propagate the exception to the global context if a successful response is malformed', async () => {
+      server = http.createServer(async (_req, res) => {
+        return makeResponse(res, 200)
+      })
+      server.listen(port)
+
+      const rs = await client.query({
+        query: 'SELECT 1',
+        format: 'JSONEachRow',
+      })
+
+      // Fails during the response streaming
+      await expectAsync(rs.text()).toBeRejectedWithError()
+    })
+  })
+
+  function makeResponse(res: http.ServerResponse, status: 200 | 500) {
+    res.appendHeader('Content-Encoding', 'gzip')
+    res.statusCode = status
+    res.write('A malformed response without compression')
+    return res.end()
+  }
+})

--- a/packages/client-node/src/connection/node_base_connection.ts
+++ b/packages/client-node/src/connection/node_base_connection.ts
@@ -465,7 +465,7 @@ export abstract class NodeBaseConnection
         // even if the stream decompression is disabled, we have to decompress it in case of an error
         const isFailedResponse = !isSuccessfulResponse(_response.statusCode)
         if (tryDecompressResponseStream || isFailedResponse) {
-          const decompressionResult = decompressResponse(_response)
+          const decompressionResult = decompressResponse(_response, this.logger)
           if (isDecompressionError(decompressionResult)) {
             return reject(decompressionResult.error)
           }
@@ -474,7 +474,13 @@ export abstract class NodeBaseConnection
           responseStream = _response
         }
         if (isFailedResponse) {
-          reject(parseError(await getAsText(responseStream)))
+          try {
+            const errorMessage = await getAsText(responseStream)
+            reject(parseError(errorMessage))
+          } catch (err) {
+            // If the ClickHouse response is malformed
+            reject(err)
+          }
         } else {
           return resolve({
             stream: responseStream,


### PR DESCRIPTION
## Summary

* Fixes #363
* Uses proper logger instance instead of `console.error` to log an error that occurs during the decoding stream

## Checklist
- [x] Unit and integration tests covering the common scenarios were added
- [x] A human-readable description of the changes was provided to include in CHANGELOG
