### PR TITLE
JWT auth fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,25 @@
+# 1.10.0 (Common, Node.js, Web)
+
+## New features
+
+- Added support for JWT authentication (ClickHouse Cloud feature) in both Node.js and Web API packages. JWT token can be set via `access_token` client configuration option.
+
+  ```ts
+  const client = createClient({
+    // ...
+    access_token: '<JWT access token>',
+  })
+  ```
+
+  Access token can also be configured via the URL params, e.g., `https://host:port?access_token=...`.
+
+  It is also possible to override the access token for a particular request (see `BaseQueryParams.auth` for more details).
+
+  NB: do not mix access token and username/password credentials in the configuration; the client will throw an error if both are set.
+
 # 1.9.1 (Node.js only)
+
+## Bug fixes
 
 - Fixed an uncaught exception that could happen in case of malformed ClickHouse response when response compression is enabled ([#363](https://github.com/ClickHouse/clickhouse-js/issues/363))
 

--- a/packages/client-common/__tests__/integration/auth.test.ts
+++ b/packages/client-common/__tests__/integration/auth.test.ts
@@ -7,10 +7,8 @@ describe('authentication', () => {
   let invalidAuthClient: ClickHouseClient
   beforeEach(() => {
     invalidAuthClient = createTestClient({
-      auth: {
-        username: 'gibberish',
-        password: 'gibberish',
-      },
+      username: 'gibberish',
+      password: 'gibberish',
     })
   })
   afterEach(async () => {

--- a/packages/client-common/__tests__/utils/client.ts
+++ b/packages/client-common/__tests__/utils/client.ts
@@ -56,7 +56,7 @@ export function createTestClient<Stream = unknown>(
   if (isCloudTestEnv()) {
     const cloudConfig: BaseClickHouseClientConfigOptions = {
       url: `https://${getFromEnv(EnvKeys.host)}:8443`,
-      auth: { password: getFromEnv(EnvKeys.password) },
+      password: getFromEnv(EnvKeys.password),
       database: databaseName,
       request_timeout: 60_000,
       ...logging,

--- a/packages/client-common/src/config.ts
+++ b/packages/client-common/src/config.ts
@@ -39,13 +39,16 @@ export interface BaseClickHouseClientConfigOptions {
     request?: boolean
   }
   /** The name of the user on whose behalf requests are made.
+   *  Should not be set if {@link access_token} is provided.
    *  @default default */
   username?: string
   /** The user password.
+   *  Should not be set if {@link access_token} is provided.
    *  @default empty string */
   password?: string
   /** A JWT access token to authenticate with ClickHouse.
    *  JWT token authentication is supported in ClickHouse Cloud only.
+   *  Should not be set if {@link username} or {@link password} are provided.
    *  @default empty */
   access_token?: string
   /** The name of the application using the JS client.

--- a/packages/client-common/src/version.ts
+++ b/packages/client-common/src/version.ts
@@ -1,1 +1,1 @@
-export default '1.9.1'
+export default '1.10.0'

--- a/packages/client-node/__tests__/integration/node_jwt_auth.test.ts
+++ b/packages/client-node/__tests__/integration/node_jwt_auth.test.ts
@@ -19,9 +19,7 @@ whenOnEnv(TestEnv.CloudSMT).describe('[Node.js] JWT auth', () => {
   it('should work with client configuration', async () => {
     jwtClient = createTestClient({
       url,
-      auth: {
-        access_token: jwt,
-      },
+      access_token: jwt,
     })
     const rs = await jwtClient.query({
       query: 'SELECT 42 AS result',
@@ -33,10 +31,8 @@ whenOnEnv(TestEnv.CloudSMT).describe('[Node.js] JWT auth', () => {
   it('should override the client instance auth', async () => {
     jwtClient = createTestClient({
       url,
-      auth: {
-        username: 'gibberish',
-        password: 'gibberish',
-      },
+      username: 'gibberish',
+      password: 'gibberish',
     })
     const rs = await jwtClient.query({
       query: 'SELECT 42 AS result',

--- a/packages/client-node/__tests__/integration/node_jwt_auth.test.ts
+++ b/packages/client-node/__tests__/integration/node_jwt_auth.test.ts
@@ -1,10 +1,11 @@
-import type { ClickHouseClient } from '@clickhouse/client-common'
-import { createTestClient, TestEnv, whenOnEnv } from '@test/utils'
+import { TestEnv, whenOnEnv } from '@test/utils'
 import { EnvKeys, getFromEnv } from '@test/utils/env'
+import { createClient } from '../../src'
+import type { NodeClickHouseClient } from '../../src/client'
 import { makeJWT } from '../utils/jwt'
 
 whenOnEnv(TestEnv.CloudSMT).describe('[Node.js] JWT auth', () => {
-  let jwtClient: ClickHouseClient
+  let jwtClient: NodeClickHouseClient
   let url: string
   let jwt: string
 
@@ -17,7 +18,7 @@ whenOnEnv(TestEnv.CloudSMT).describe('[Node.js] JWT auth', () => {
   })
 
   it('should work with client configuration', async () => {
-    jwtClient = createTestClient({
+    jwtClient = createClient({
       url,
       access_token: jwt,
     })
@@ -29,7 +30,7 @@ whenOnEnv(TestEnv.CloudSMT).describe('[Node.js] JWT auth', () => {
   })
 
   it('should override the client instance auth', async () => {
-    jwtClient = createTestClient({
+    jwtClient = createClient({
       url,
       username: 'gibberish',
       password: 'gibberish',

--- a/packages/client-node/src/version.ts
+++ b/packages/client-node/src/version.ts
@@ -1,1 +1,1 @@
-export default '1.9.1'
+export default '1.10.0'

--- a/packages/client-web/__tests__/jwt/web_jwt_auth.test.ts
+++ b/packages/client-web/__tests__/jwt/web_jwt_auth.test.ts
@@ -21,9 +21,7 @@ describe('[Web] JWT auth', () => {
   it('should work with client configuration', async () => {
     client = createTestClient({
       url,
-      auth: {
-        access_token: jwt,
-      },
+      access_token: jwt,
     })
     const rs = await client.query({
       query: 'SELECT 42 AS result',
@@ -35,10 +33,8 @@ describe('[Web] JWT auth', () => {
   it('should override the client instance auth', async () => {
     client = createTestClient({
       url,
-      auth: {
-        username: 'gibberish',
-        password: 'gibberish',
-      },
+      username: 'gibberish',
+      password: 'gibberish',
     })
     const rs = await client.query({
       query: 'SELECT 42 AS result',

--- a/packages/client-web/__tests__/jwt/web_jwt_auth.test.ts
+++ b/packages/client-web/__tests__/jwt/web_jwt_auth.test.ts
@@ -1,12 +1,12 @@
-import type { ClickHouseClient } from '@clickhouse/client-common'
-import { createTestClient } from '@test/utils'
 import { EnvKeys, getFromEnv } from '@test/utils/env'
+import { createClient } from '../../src'
+import type { WebClickHouseClient } from '../../src/client'
 
 /** Cannot use the jsonwebtoken library to generate the token: it is Node.js only.
  *  The access token should be generated externally before running the test,
  *  and set as the CLICKHOUSE_JWT_ACCESS_TOKEN environment variable */
 describe('[Web] JWT auth', () => {
-  let client: ClickHouseClient
+  let client: WebClickHouseClient
   let url: string
   let jwt: string
 
@@ -19,7 +19,7 @@ describe('[Web] JWT auth', () => {
   })
 
   it('should work with client configuration', async () => {
-    client = createTestClient({
+    client = createClient({
       url,
       access_token: jwt,
     })
@@ -31,7 +31,7 @@ describe('[Web] JWT auth', () => {
   })
 
   it('should override the client instance auth', async () => {
-    client = createTestClient({
+    client = createClient({
       url,
       username: 'gibberish',
       password: 'gibberish',

--- a/packages/client-web/src/version.ts
+++ b/packages/client-web/src/version.ts
@@ -1,1 +1,1 @@
-export default '1.9.1'
+export default '1.10.0'


### PR DESCRIPTION
## Summary

- Keep `username`/`password` on the top level of the config object as it was before #270 
- Move `access_token` to the top level of the config object
- If `access_token` is set alongside `username` or `password`, the client will throw an error.
- Updated the tests and the JS doc
- Updated the changelog 
- Bump the version to 1.10.0

Website docs will be updated shortly after the new release.

## Checklist
- [x] Unit and integration tests covering the common scenarios were added
- [x] A human-readable description of the changes was provided to include in CHANGELOG

