### PR TITLE
Add `session_timeout` and `session_check` settings typings

### DIFF
--- a/packages/client-common/src/settings.ts
+++ b/packages/client-common/src/settings.ts
@@ -1596,8 +1596,11 @@ interface ClickHouseHTTPSettings {
   /** By default, the session is terminated after 60 seconds of inactivity
    *  This is regulated by the `default_session_timeout` server setting. */
   session_timeout: UInt64
-  /** To check the session status, you can use this setting.
-   *  If a session is expired or cannot be found, server returns `SESSION_NOT_FOUND` with error code 372. */
+  /** You can use this setting to check the session status before executing the query.
+   *  If a session is expired or cannot be found, the server returns `SESSION_NOT_FOUND` with error code 372. 
+   *  NB: the session mechanism is only reliable when you connect directly to a particular ClickHouse server node. 
+   *  Due to each particular session not being shared across the cluster, sessions won't work well in a multi-node environment with a load balancer, 
+   *  as there will be no guarantee that each consequent request will be received on the same node. */
   session_check: Bool
 }
 

--- a/packages/client-common/src/settings.ts
+++ b/packages/client-common/src/settings.ts
@@ -1581,9 +1581,24 @@ interface ClickHouseServerSettings {
   zstd_window_log_max?: Int64
 }
 
+/** @see https://clickhouse.com/docs/en/interfaces/http */
 interface ClickHouseHTTPSettings {
+  /** Ensures that the entire response is buffered.
+   *  In this case, the data that is not stored in memory will be buffered in a temporary server file.
+   *  This could help prevent errors that might occur during the streaming of SELECT queries.
+   *  Additionally, this is useful when executing DDLs on clustered environments,
+   *  as the client will receive the response only when the DDL is applied on all nodes of the cluster. */
   wait_end_of_query: Bool
+  /** Format to use if a SELECT query is executed without a FORMAT clause.
+   *  Only useful for the {@link ClickHouseClient.exec} method,
+   *  as {@link ClickHouseClient.query} method always attaches this clause. */
   default_format: DataFormat
+  /** By default, the session is terminated after 60 seconds of inactivity
+   *  This is regulated by the `default_session_timeout` server setting. */
+  session_timeout: UInt64
+  /** To check the session status, you can use this setting.
+   *  If a session is expired or cannot be found, server returns `SESSION_NOT_FOUND` with error code 372. */
+  session_check: Bool
 }
 
 export type ClickHouseSettings = Partial<ClickHouseServerSettings> &

--- a/packages/client-common/src/settings.ts
+++ b/packages/client-common/src/settings.ts
@@ -1597,9 +1597,9 @@ interface ClickHouseHTTPSettings {
    *  This is regulated by the `default_session_timeout` server setting. */
   session_timeout: UInt64
   /** You can use this setting to check the session status before executing the query.
-   *  If a session is expired or cannot be found, the server returns `SESSION_NOT_FOUND` with error code 372. 
-   *  NB: the session mechanism is only reliable when you connect directly to a particular ClickHouse server node. 
-   *  Due to each particular session not being shared across the cluster, sessions won't work well in a multi-node environment with a load balancer, 
+   *  If a session is expired or cannot be found, the server returns `SESSION_NOT_FOUND` with error code 372.
+   *  NB: the session mechanism is only reliable when you connect directly to a particular ClickHouse server node.
+   *  Due to each particular session not being shared across the cluster, sessions won't work well in a multi-node environment with a load balancer,
    *  as there will be no guarantee that each consequent request will be received on the same node. */
   session_check: Bool
 }


### PR DESCRIPTION
## Summary

Related to #370. It is possible to use these settings anyway cause the typings are not very strict; however, it is more convenient to have it there for autocomplete. 

Added some docs entries there as well.

See also https://clickhouse.com/docs/en/interfaces/http#default-database
