### PR TITLE
Fix NULL parameters in Tuples/Maps/Arrays

### DIFF
--- a/packages/client-common/__tests__/unit/format_query_params.test.ts
+++ b/packages/client-common/__tests__/unit/format_query_params.test.ts
@@ -2,89 +2,147 @@ import { formatQueryParams } from '@clickhouse/client-common'
 
 describe('formatQueryParams', () => {
   it('formats null', () => {
-    expect(formatQueryParams(null)).toBe('\\N')
+    expect(
+      formatQueryParams({
+        value: null,
+      }),
+    ).toBe('\\N')
   })
 
   it('formats undefined', () => {
-    expect(formatQueryParams(undefined)).toBe('\\N')
+    expect(
+      formatQueryParams({
+        value: undefined,
+      }),
+    ).toBe('\\N')
   })
 
   it('formats boolean', () => {
-    expect(formatQueryParams(true)).toBe('1')
-    expect(formatQueryParams(false)).toBe('0')
+    expect(
+      formatQueryParams({
+        value: true,
+      }),
+    ).toBe('1')
+    expect(
+      formatQueryParams({
+        value: false,
+      }),
+    ).toBe('0')
   })
 
   it('formats number', () => {
-    expect(formatQueryParams(1)).toBe('1')
+    expect(
+      formatQueryParams({
+        value: 1,
+      }),
+    ).toBe('1')
   })
 
   it('formats NaN', () => {
-    expect(formatQueryParams(NaN)).toBe('nan')
+    expect(
+      formatQueryParams({
+        value: NaN,
+      }),
+    ).toBe('nan')
   })
 
   it('formats Infinity', () => {
-    expect(formatQueryParams(Infinity)).toBe('+inf')
-    expect(formatQueryParams(+Infinity)).toBe('+inf')
-    expect(formatQueryParams(-Infinity)).toBe('-inf')
+    expect(
+      formatQueryParams({
+        value: Infinity,
+      }),
+    ).toBe('+inf')
+    expect(
+      formatQueryParams({
+        value: +Infinity,
+      }),
+    ).toBe('+inf')
+    expect(
+      formatQueryParams({
+        value: -Infinity,
+      }),
+    ).toBe('-inf')
   })
 
   it('formats an array', () => {
-    expect(formatQueryParams([1, 2, 3])).toBe('[1,2,3]')
+    expect(formatQueryParams({ value: [1, 2, 3] })).toBe('[1,2,3]')
   })
 
   it('formats an empty Array', () => {
-    expect(formatQueryParams([])).toBe('[]')
+    expect(formatQueryParams({ value: [] })).toBe('[]')
   })
 
   it('formats a date without timezone', () => {
     const date = new Date(Date.UTC(2022, 6, 29, 7, 52, 14))
 
-    expect(formatQueryParams(date)).toBe('1659081134')
+    expect(
+      formatQueryParams({
+        value: date,
+      }),
+    ).toBe('1659081134')
   })
 
   it('formats a date with only nine digits in its Unix timestamp (seconds)', () => {
     const date = new Date(Date.UTC(1973, 10, 29, 21, 33, 9))
 
-    expect(formatQueryParams(date)).toBe('0123456789')
+    expect(
+      formatQueryParams({
+        value: date,
+      }),
+    ).toBe('0123456789')
   })
 
   it('formats a date with millis', () => {
     expect(
-      formatQueryParams(new Date(Date.UTC(2022, 6, 29, 7, 52, 14, 123))),
+      formatQueryParams({
+        value: new Date(Date.UTC(2022, 6, 29, 7, 52, 14, 123)),
+      }),
     ).toBe('1659081134.123')
     expect(
-      formatQueryParams(new Date(Date.UTC(2022, 6, 29, 7, 52, 14, 42))),
+      formatQueryParams({
+        value: new Date(Date.UTC(2022, 6, 29, 7, 52, 14, 42)),
+      }),
     ).toBe('1659081134.042')
     expect(
-      formatQueryParams(new Date(Date.UTC(2022, 6, 29, 7, 52, 14, 5))),
+      formatQueryParams({
+        value: new Date(Date.UTC(2022, 6, 29, 7, 52, 14, 5)),
+      }),
     ).toBe('1659081134.005')
   })
 
   it('does not wrap a string in quotes', () => {
-    expect(formatQueryParams('hello')).toBe('hello')
+    expect(
+      formatQueryParams({
+        value: 'hello',
+      }),
+    ).toBe('hello')
   })
 
   it('escapes special characters in an input string', () => {
-    expect(formatQueryParams("hel'lo")).toBe("hel\\'lo")
-    expect(formatQueryParams('hel\\lo')).toBe('hel\\\\lo')
-    expect(formatQueryParams('hel\tlo')).toBe('hel\\tlo')
-    expect(formatQueryParams('hel\nlo')).toBe('hel\\nlo')
-    expect(formatQueryParams('hel\rlo')).toBe('hel\\rlo')
+    expect(formatQueryParams({ value: "hel'lo" })).toBe("hel\\'lo")
+    expect(formatQueryParams({ value: 'hel\\lo' })).toBe('hel\\\\lo')
+    expect(formatQueryParams({ value: 'hel\tlo' })).toBe('hel\\tlo')
+    expect(formatQueryParams({ value: 'hel\nlo' })).toBe('hel\\nlo')
+    expect(formatQueryParams({ value: 'hel\rlo' })).toBe('hel\\rlo')
   })
 
   it('wraps strings in an array in quotes', () => {
-    expect(formatQueryParams(['1', '2'])).toBe("['1','2']")
+    expect(formatQueryParams({ value: ['1', '2'] })).toBe("['1','2']")
   })
 
   it('formats an object and escapes keys and values', () => {
     expect(
       formatQueryParams({
-        ["na'me"]: "cust'om",
+        value: {
+          ["na'me"]: "cust'om",
+        },
       }),
     ).toBe("{'na\\'me':'cust\\'om'}")
     expect(
       formatQueryParams({
-        ["a'b\nc\td\re\\"]: "\\q'w\ne\tr\rt\\y",
+        value: {
+          ["a'b\nc\td\re\\"]: "\\q'w\ne\tr\rt\\y",
+        },
       }),
     ).toBe("{'a\\'b\\nc\\td\\re\\\\':'\\\\q\\'w\\ne\\tr\\rt\\\\y'}")
   })
@@ -92,9 +150,11 @@ describe('formatQueryParams', () => {
   it('formats a nested object', () => {
     expect(
       formatQueryParams({
-        name: 'custom',
-        id: 42,
-        params: { refs: [44] },
+        value: {
+          name: 'custom',
+          id: 42,
+          params: { refs: [44] },
+        },
       }),
     ).toBe("{'name':'custom','id':42,'params':{'refs':[44]}}")
   })

--- a/packages/client-common/src/utils/url.ts
+++ b/packages/client-common/src/utils/url.ts
@@ -56,7 +56,7 @@ export function toSearchParams({
 
   if (query_params !== undefined) {
     for (const [key, value] of Object.entries(query_params)) {
-      const formattedParam = formatQueryParams(value)
+      const formattedParam = formatQueryParams({ value })
       params.set(`param_${key}`, formattedParam)
     }
   }


### PR DESCRIPTION
## Summary

Resolves #374
There was a similar issue with `Array`/`Map` types, too - JS `null` and `undefined` should be printed as the `NULL` keyword instead of `\N` there, as `\N` can be used only for non-nested types, e.g. for something like `Nullable(Int32)`.

See
```
curl "http://localhost:8123?param_tup=%5B'foo',NULL%5D" --data-binary "SELECT {tup: Array(Nullable(String))} t" 
['foo',NULL]
```

```
curl "http://localhost:8123?param_tup=%5B'foo',\N%5D" --data-binary "SELECT {tup: Array(Nullable(String))} t"
Code: 26. DB::Exception: Cannot parse quoted string: expected opening quote ''', got '\': value ['foo',\N] cannot be parsed as Array(Nullable(String)) for query parameter 'tup'. (CANNOT_PARSE_QUOTED_STRING) (version 24.12.2.29 (official build))
```

But
```
curl "http://localhost:8123?param_tup=\N" --data-binary "SELECT {tup: Nullable(String)} t"  
\N
```

## Checklist
- [x] Unit and integration tests covering the common scenarios were added
- [x] A human-readable description of the changes was provided to include in CHANGELOG
