### PR TITLE
Handle errors in a middle of a stream

### DIFF
--- a/packages/client-common/src/settings.ts
+++ b/packages/client-common/src/settings.ts
@@ -1583,6 +1583,7 @@ interface ClickHouseServerSettings {
 
 /** @see https://clickhouse.com/docs/en/interfaces/http */
 interface ClickHouseHTTPSettings {
+  http_write_exception_in_output_format: Bool
   /** Ensures that the entire response is buffered.
    *  In this case, the data that is not stored in memory will be buffered in a temporary server file.
    *  This could help prevent errors that might occur during the streaming of SELECT queries.

--- a/packages/client-node/__tests__/integration/node_streaming_errors.test.ts
+++ b/packages/client-node/__tests__/integration/node_streaming_errors.test.ts
@@ -1,0 +1,83 @@
+import {
+  ClickHouseError,
+  type ClickHouseSettings,
+} from '@clickhouse/client-common'
+import { createTestClient } from '@test/utils'
+import { StreamableDataFormat } from '../../src'
+import { NodeClickHouseClient } from '../../src/client'
+
+fdescribe('[Node.js] Errors during streaming', () => {
+  let client: NodeClickHouseClient
+  beforeAll(() => {
+    client = createTestClient() as NodeClickHouseClient
+  })
+  afterAll(async () => {
+    await client.close()
+  })
+
+  it('should work with CSV', async () => {
+    let err: unknown
+    let rowsCount = 0
+    try {
+      const rs = await runQuery('CSV')
+      const stream = rs.stream()
+      for await (const rows of stream) {
+        rowsCount += rows.length
+      }
+    } catch (e) {
+      err = e
+    }
+    assertStreamFailure(rowsCount, err)
+  })
+
+  fit('should work with JSONEachRow', async () => {
+    let err: unknown
+    let rowsCount = 0
+    try {
+      const rs = await runQuery('JSONEachRow', {
+        http_write_exception_in_output_format: 0,
+      })
+      const stream = rs.stream()
+      for await (const rows of stream) {
+        for (const row of rows) {
+          row.json() // should not produce SyntaxError
+          rowsCount++
+        }
+      }
+    } catch (e) {
+      err = e
+    }
+    assertStreamFailure(rowsCount, err)
+  })
+
+  function runQuery<F extends StreamableDataFormat>(
+    format: F,
+    settings?: ClickHouseSettings,
+  ) {
+    return client.query({
+      query: `
+        SELECT
+            number,
+            if(number > 20, throwIf(1, 'Boom'), number) AS value
+        FROM numbers(1000)
+      `,
+      format,
+      clickhouse_settings: {
+        // Forces CH to send more chunks of data (1 row each),
+        // so that we get 200 OK + headers first instead of 500 ISE
+        max_block_size: '1',
+        ...(settings ?? {}),
+      },
+    })
+  }
+
+  function assertStreamFailure(rowsCount: number, err: unknown) {
+    // rows count may vary, but the last row will always contain the error message
+    expect(rowsCount).toBeGreaterThanOrEqual(10)
+    expect(err).toBeInstanceOf(ClickHouseError)
+    expect((err as ClickHouseError).code).toBe('395')
+    expect((err as ClickHouseError).type).toBe(
+      'FUNCTION_THROW_IF_VALUE_IS_NON_ZERO',
+    )
+  }
+})

--- a/packages/client-node/__tests__/integration/node_streaming_errors.test.ts
+++ b/packages/client-node/__tests__/integration/node_streaming_errors.test.ts
@@ -3,10 +3,10 @@ import {
   type ClickHouseSettings,
 } from '@clickhouse/client-common'
 import { createTestClient } from '@test/utils'
-import { StreamableDataFormat } from '../../src'
-import { NodeClickHouseClient } from '../../src/client'
+import type { StreamableDataFormat } from '../../src'
+import type { NodeClickHouseClient } from '../../src/client'
 
-fdescribe('[Node.js] Errors during streaming', () => {
+describe('[Node.js] Errors during streaming', () => {
   let client: NodeClickHouseClient
   beforeAll(() => {
     client = createTestClient() as NodeClickHouseClient
@@ -30,7 +30,7 @@ fdescribe('[Node.js] Errors during streaming', () => {
     assertStreamFailure(rowsCount, err)
   })
 
-  fit('should work with JSONEachRow', async () => {
+  it('should work with JSONEachRow', async () => {
     let err: unknown
     let rowsCount = 0
     try {

--- a/packages/client-node/src/result_set.ts
+++ b/packages/client-node/src/result_set.ts
@@ -160,8 +160,8 @@ export class ResultSet<Format extends DataFormat | unknown>
               // to be processed during the first pass for the next chunk
               incompleteChunks.push(chunk.subarray(lastIdx))
               // error reporting goes like this:
-              // __exception__\r\n // - the row before the last one
-              // Code: X. DB::Exception: ...\n // - the very last row
+              // __exception__\r\n              // - the row before the last one
+              // Code: X. DB::Exception: ...\n  // - the very last row
               // we are not going to push these rows downstream
               if (
                 rows.length > 1 &&


### PR DESCRIPTION
## Summary

ResultSet implementation was adjusted given the changes from 24.11 and https://github.com/ClickHouse/ClickHouse/pull/68800; formats like CSV will properly throw by default if an error occurs during the stream. `JSONEachRow` and other streamable formats require `http_write_exception_in_output_format: 0` in `clickhouse_settings`, so ClickHouse breaks the output stream in a similar way.

Important: The `http_write_exception_in_output_format` default value is 1; if it is not modified, the data stream with formats like `JSONEachRow` will not be broken if an error occurs. 

Here are some curl examples.

This will have exit code 0:
```
curl "http://localhost:8123" --data-binary "select throwIf(number = 3, 'There was an error in the stream!') AS _, randomPrintableASCII(20) AS str from system.numbers limit 30000 SETTINGS max_block_size=1 FORMAT JSONCompactEachRow" 
 
[0, ">w$zM[t3K(t#y(MhOB\/]"]
["Code: 395. DB::Exception: There was an error in the stream!: while executing 'FUNCTION throwIf(equals(__table1.number, 3_UInt8) :: 3, 'There was an error in the stream!'_String :: 2) -> throwIf(equals(__table1.number, 3_UInt8), 'There was an error in the stream!'_String) UInt8 : 0'. (FUNCTION_THROW_IF_VALUE_IS_NON_ZERO) (version 24.12.2.29 (official build))"]
```

But this will have exit code 18 (see `http_write_exception_in_output_format=0` in the params):
```
curl "http://localhost:8123?http_write_exception_in_output_format=0" --data-binary "select throwIf(number = 3, 'There was an error in the stream!') AS _, randomPrintableASCII(20) AS str from system.numbers limit 30000 SETTINGS max_block_size=1 FORMAT JSONCompactEachRow"

[0, "n\\|Y>U`Qa)op\"}0hcblo"]
__exception__
Code: 395. DB::Exception: There was an error in the stream!: while executing 'FUNCTION throwIf(equals(__table1.number, 3_UInt8) :: 3, 'There was an error in the stream!'_String :: 2) -> throwIf(equals(__table1.number, 3_UInt8), 'There was an error in the stream!'_String) UInt8 : 0'. (FUNCTION_THROW_IF_VALUE_IS_NON_ZERO) (version 24.12.2.29 (official build))
curl: (18) transfer closed with outstanding read data remaining
```

Related to #332 and #378

## Checklist
- [x] Unit and integration tests covering the common scenarios were added
- [x] A human-readable description of the changes was provided to include in CHANGELOG
