### PR TITLE
feat(node): add paramters to forward OTEL Headers to Clickhouse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 1.10.2
+
+## Improvements
+- Added `opentelemetry_headers` option to the client configuration. ([#394](https://github.com/ClickHouse/clickhouse-js/issues/374))
+
 # 1.10.1 (Common, Node.js, Web)
 
 ## Bug fixes

--- a/packages/client-common/src/client.ts
+++ b/packages/client-common/src/client.ts
@@ -43,6 +43,12 @@ export interface BaseQueryParams {
         password: string
       }
     | { access_token: string }
+  /** OpenTelemetry headers to propagate to ClickHouse.
+   *  @default undefined (no override) */
+  opentelemetry_headers?: {
+    traceparent?: string
+    tracestate?: string
+  }
 }
 
 export interface QueryParams extends BaseQueryParams {
@@ -308,6 +314,7 @@ export class ClickHouseClient<Stream = unknown> {
       session_id: params.session_id ?? this.sessionId,
       role: params.role ?? this.role,
       auth: params.auth,
+      opentelemetry_headers: params.opentelemetry_headers,
     }
   }
 }

--- a/packages/client-common/src/connection.ts
+++ b/packages/client-common/src/connection.ts
@@ -37,6 +37,10 @@ export interface ConnBaseQueryParams {
   query_id?: string
   auth?: { username: string; password: string } | { access_token: string }
   role?: string | Array<string>
+  opentelemetry_headers?: {
+    traceparent?: string
+    tracestate?: string
+  }
 }
 
 export interface ConnInsertParams<Stream> extends ConnBaseQueryParams {

--- a/packages/client-node/src/connection/node_base_connection.ts
+++ b/packages/client-node/src/connection/node_base_connection.ts
@@ -265,27 +265,37 @@ export abstract class NodeBaseConnection
   protected buildRequestHeaders(
     params?: BaseQueryParams,
   ): Http.OutgoingHttpHeaders {
+    const headers = { ...this.defaultHeaders }
+
+    if (params?.opentelemetry_headers?.traceparent) {
+      headers['traceparent'] = params.opentelemetry_headers.traceparent
+    }
+
+    if (params?.opentelemetry_headers?.tracestate) {
+      headers['tracestate'] = params.opentelemetry_headers.tracestate
+    }
+
     if (isJWTAuth(params?.auth)) {
       return {
-        ...this.defaultHeaders,
+        ...headers,
         Authorization: `Bearer ${params.auth.access_token}`,
       }
     }
     if (this.params.set_basic_auth_header) {
       if (isCredentialsAuth(params?.auth)) {
         return {
-          ...this.defaultHeaders,
+          ...headers,
           Authorization: `Basic ${Buffer.from(`${params.auth.username}:${params.auth.password}`).toString('base64')}`,
         }
       } else {
         return {
-          ...this.defaultHeaders,
+          ...headers,
           Authorization: this.defaultAuthHeader,
         }
       }
     }
     return {
-      ...this.defaultHeaders,
+      ...headers,
     }
   }
 


### PR DESCRIPTION
## Summary
Addresses #394, Clickhouse supports reading the OTEL HTTP headers from the connection

## Checklist
- [x] Unit tests covering the common scenarios were added
- [x] A human-readable description of the changes was provided to include in CHANGELOG
