### PR TITLE
Support passing a custom `fetch` function

### DIFF
--- a/packages/client-web/src/config.ts
+++ b/packages/client-web/src/config.ts
@@ -9,10 +9,16 @@ import { WebConnection } from './connection'
 import { ResultSet } from './result_set'
 import { WebValuesEncoder } from './utils'
 
-export type WebClickHouseClientConfigOptions = BaseClickHouseClientConfigOptions
+export type WebClickHouseClientConfigOptions =
+  BaseClickHouseClientConfigOptions & {
+    fetch?: (url: string, init: RequestInit) => Promise<Response>
+  }
 
 export const WebImpl: ImplementationDetails<ReadableStream>['impl'] = {
-  make_connection: (_, params: ConnectionParams) => new WebConnection(params),
+  make_connection: (
+    config: WebClickHouseClientConfigOptions,
+    params: ConnectionParams,
+  ) => new WebConnection(params, config.fetch),
   make_result_set: ((
     stream: ReadableStream,
     format: DataFormat,

--- a/packages/client-web/src/connection/web_connection.ts
+++ b/packages/client-web/src/connection/web_connection.ts
@@ -32,7 +32,13 @@ export type WebConnectionParams = ConnectionParams
 
 export class WebConnection implements Connection<ReadableStream> {
   private readonly defaultHeaders: Record<string, string>
-  constructor(private readonly params: WebConnectionParams) {
+  constructor(
+    private readonly params: WebConnectionParams,
+    private readonly fetch?: (
+      url: string,
+      init: RequestInit,
+    ) => Promise<Response>,
+  ) {
     if (params.auth.type === 'JWT') {
       this.defaultHeaders = {
         Authorization: `Bearer ${params.auth.access_token}`,
@@ -197,6 +203,7 @@ export class WebConnection implements Connection<ReadableStream> {
         enable_response_compression:
           this.params.compression.decompress_response,
       })
+      const fetch = this.fetch ?? globalThis.fetch
       const response = await fetch(url, {
         body: values,
         headers,


### PR DESCRIPTION
## Summary

This commit adds support for passing a custom `fetch` function to the web client.

This is useful if you are not using global `fetch`, but rather need to use a different implementation or wrapper, for example for because you want to to use a custom HTTP agent/client to be able to configure mTLS or h1/h2 support settings.

I personally need this to be able to set mTLS settings for `fetch` when using this library from Deno.

## Checklist
Delete items not relevant to your PR:
- [ ] Unit and integration tests covering the common scenarios were added
- [ ] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
