### PR TITLE
Allow to override HTTP headers on the method level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 1.10.2
+
+## Improvements
+- Added `opentelemetry_headers` option to the client configuration. ([#394](https://github.com/ClickHouse/clickhouse-js/issues/374))
+
 # 1.10.1 (Common, Node.js, Web)
 
 ## Bug fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
-# 1.10.2
+# 1.11.0 (Common, Node.js, Web)
 
-## Improvements
-- Added `opentelemetry_headers` option to the client configuration. ([#394](https://github.com/ClickHouse/clickhouse-js/issues/374))
+## New features
+
+- It is now possible to provide custom HTTP headers when calling the `query`/`insert`/`command`/`exec` methods using the `http_headers` option. NB: `http_headers` specified this way will override `http_headers` set on the client instance level. ([#394](https://github.com/ClickHouse/clickhouse-js/issues/374), [@DylanRJohnston](https://github.com/DylanRJohnston))
 
 # 1.10.1 (Common, Node.js, Web)
 

--- a/package.json
+++ b/package.json
@@ -80,7 +80,6 @@
     "source-map-support": "^0.5.21",
     "split2": "^4.2.0",
     "terser-webpack-plugin": "^5.3.10",
-    "ts-jest": "^29.2.5",
     "ts-loader": "^9.5.1",
     "ts-node": "^10.9.2",
     "tsconfig-paths": "^4.2.0",

--- a/packages/client-common/__tests__/utils/parametrized.ts
+++ b/packages/client-common/__tests__/utils/parametrized.ts
@@ -1,0 +1,30 @@
+import type { ClickHouseClient } from '@clickhouse/client-common'
+
+const baseClientMethod = ['query', 'command', 'exec'] as const
+interface TestParam {
+  methodName: (typeof baseClientMethod)[number] | 'insert'
+  methodCall: (http_headers: Record<string, string>) => Promise<unknown>
+}
+
+export function getHeadersTestParams<Stream>(
+  client: Pick<ClickHouseClient<Stream>, TestParam['methodName']>,
+): Array<TestParam> {
+  const testParams: Array<TestParam> = baseClientMethod.map((methodName) => ({
+    methodName,
+    methodCall: (http_headers) =>
+      client[methodName]({
+        query: 'SELECT 42',
+        http_headers,
+      }),
+  }))
+  testParams.push({
+    methodName: 'insert',
+    methodCall: (http_headers) =>
+      client.insert({
+        table: 'foo',
+        values: ['foo', 'bar'],
+        http_headers,
+      }),
+  })
+  return testParams
+}

--- a/packages/client-common/src/client.ts
+++ b/packages/client-common/src/client.ts
@@ -43,6 +43,12 @@ export interface BaseQueryParams {
         password: string
       }
     | { access_token: string }
+  /** OpenTelemetry headers to propagate to ClickHouse.
+   *  @default undefined (no override) */
+  opentelemetry_headers?: {
+    traceparent?: string
+    tracestate?: string
+  }
 }
 
 export interface QueryParams extends BaseQueryParams {
@@ -308,6 +314,7 @@ export class ClickHouseClient<Stream = unknown> {
       session_id: params.session_id ?? this.sessionId,
       role: params.role ?? this.role,
       auth: params.auth,
+      opentelemetry_headers: params.opentelemetry_headers,
     }
   }
 }

--- a/packages/client-common/src/client.ts
+++ b/packages/client-common/src/client.ts
@@ -43,12 +43,10 @@ export interface BaseQueryParams {
         password: string
       }
     | { access_token: string }
-  /** OpenTelemetry headers to propagate to ClickHouse.
-   *  @default undefined (no override) */
-  opentelemetry_headers?: {
-    traceparent?: string
-    tracestate?: string
-  }
+  /** Additional HTTP headers to attach to this particular request.
+   *  Overrides the headers set in {@link BaseClickHouseClientConfigOptions.http_headers}.
+   *  @default empty object */
+  http_headers?: Record<string, string>
 }
 
 export interface QueryParams extends BaseQueryParams {
@@ -314,7 +312,7 @@ export class ClickHouseClient<Stream = unknown> {
       session_id: params.session_id ?? this.sessionId,
       role: params.role ?? this.role,
       auth: params.auth,
-      opentelemetry_headers: params.opentelemetry_headers,
+      http_headers: params.http_headers,
     }
   }
 }

--- a/packages/client-common/src/connection.ts
+++ b/packages/client-common/src/connection.ts
@@ -37,6 +37,10 @@ export interface ConnBaseQueryParams {
   query_id?: string
   auth?: { username: string; password: string } | { access_token: string }
   role?: string | Array<string>
+  opentelemetry_headers?: {
+    traceparent?: string
+    tracestate?: string
+  }
 }
 
 export interface ConnInsertParams<Stream> extends ConnBaseQueryParams {

--- a/packages/client-common/src/connection.ts
+++ b/packages/client-common/src/connection.ts
@@ -37,10 +37,7 @@ export interface ConnBaseQueryParams {
   query_id?: string
   auth?: { username: string; password: string } | { access_token: string }
   role?: string | Array<string>
-  opentelemetry_headers?: {
-    traceparent?: string
-    tracestate?: string
-  }
+  http_headers?: Record<string, string>
 }
 
 export interface ConnInsertParams<Stream> extends ConnBaseQueryParams {

--- a/packages/client-node/__tests__/integration/node_client.test.ts
+++ b/packages/client-node/__tests__/integration/node_client.test.ts
@@ -1,3 +1,4 @@
+import { getHeadersTestParams } from '@test/utils/parametrized'
 import Http from 'http'
 import type { ClickHouseClient } from '../../src'
 import { createClient } from '../../src'
@@ -67,6 +68,45 @@ describe('[Node.js] Client', () => {
       const [callURL, callOptions] = httpRequestStub.calls.mostRecent().args
       expect(callOptions.headers).toEqual(defaultHeaders)
       assertSearchParams(callURL)
+    })
+
+    it('should work with additional HTTP headers on the method level', async () => {
+      const client = createClient({
+        http_headers: {
+          FromInstance: 'foo',
+        },
+      })
+
+      async function withEmit(method: () => Promise<unknown>) {
+        const promise = method()
+        await emitResponseBody(clientRequest, 'hi')
+        await promise
+      }
+
+      let requestCalls = 1
+      const testParams = getHeadersTestParams(client)
+      for (const param of testParams) {
+        await withEmit(() => param.methodCall({ FromMethod: 'bar' }))
+        expect(getRequestHeaders(requestCalls++))
+          .withContext(
+            `${param.methodName}: merges custom HTTP headers from both method and instance`,
+          )
+          .toEqual({
+            ...defaultHeaders,
+            FromInstance: 'foo',
+            FromMethod: 'bar',
+          })
+
+        await withEmit(() => param.methodCall({ FromInstance: 'bar' }))
+        expect(getRequestHeaders(requestCalls++))
+          .withContext(
+            `${param.methodName}: overrides HTTP headers from the instance with the values from the method call`,
+          )
+          .toEqual({
+            ...defaultHeaders,
+            FromInstance: 'bar',
+          })
+      }
     })
   })
 
@@ -152,6 +192,12 @@ describe('[Node.js] Client', () => {
     const searchParams = new URL(callURL).searchParams
     expect(searchParams.get('query_id')).not.toBeNull()
     expect(searchParams.size).toEqual(1) // only query_id by default
+  }
+
+  function getRequestHeaders(httpRequestStubCalledTimes = 1) {
+    expect(httpRequestStub).toHaveBeenCalledTimes(httpRequestStubCalledTimes)
+    const [, callOptions] = httpRequestStub.calls.mostRecent().args
+    return callOptions.headers
   }
 
   const defaultHeaders: Record<

--- a/packages/client-node/__tests__/integration/node_client.test.ts
+++ b/packages/client-node/__tests__/integration/node_client.test.ts
@@ -47,6 +47,7 @@ describe('[Node.js] Client', () => {
       const client = createClient({
         http_headers: {
           'Test-Header': 'foobar',
+          Authorization: 'should-be-overridden-by-client-anyway',
         },
       })
       await query(client)
@@ -74,6 +75,7 @@ describe('[Node.js] Client', () => {
       const client = createClient({
         http_headers: {
           FromInstance: 'foo',
+          Authorization: 'should-be-overridden-by-client-anyway',
         },
       })
 

--- a/packages/client-node/src/connection/node_base_connection.ts
+++ b/packages/client-node/src/connection/node_base_connection.ts
@@ -265,27 +265,37 @@ export abstract class NodeBaseConnection
   protected buildRequestHeaders(
     params?: BaseQueryParams,
   ): Http.OutgoingHttpHeaders {
+    const headers = { ...this.defaultHeaders }
+
+    if (params?.opentelemetry_headers?.traceparent) {
+      headers['traceparent'] = params.opentelemetry_headers.traceparent
+    }
+
+    if (params?.opentelemetry_headers?.tracestate) {
+      headers['tracestate'] = params.opentelemetry_headers.tracestate
+    }
+
     if (isJWTAuth(params?.auth)) {
       return {
-        ...this.defaultHeaders,
+        ...headers,
         Authorization: `Bearer ${params.auth.access_token}`,
       }
     }
     if (this.params.set_basic_auth_header) {
       if (isCredentialsAuth(params?.auth)) {
         return {
-          ...this.defaultHeaders,
+          ...headers,
           Authorization: `Basic ${Buffer.from(`${params.auth.username}:${params.auth.password}`).toString('base64')}`,
         }
       } else {
         return {
-          ...this.defaultHeaders,
+          ...headers,
           Authorization: this.defaultAuthHeader,
         }
       }
     }
     return {
-      ...this.defaultHeaders,
+      ...headers,
     }
   }
 

--- a/packages/client-node/src/connection/node_https_connection.ts
+++ b/packages/client-node/src/connection/node_https_connection.ts
@@ -1,8 +1,8 @@
 import {
-  type BaseQueryParams,
+  type ConnBaseQueryParams,
   isCredentialsAuth,
+  withCompressionHeaders,
 } from '@clickhouse/client-common'
-import { withCompressionHeaders } from '@clickhouse/client-common'
 import type Http from 'http'
 import Https from 'https'
 import type {
@@ -24,7 +24,7 @@ export class NodeHttpsConnection extends NodeBaseConnection {
   }
 
   protected override buildRequestHeaders(
-    params?: BaseQueryParams,
+    params?: ConnBaseQueryParams,
   ): Http.OutgoingHttpHeaders {
     if (this.params.tls !== undefined) {
       if (this.params.auth.type === 'JWT') {
@@ -35,13 +35,13 @@ export class NodeHttpsConnection extends NodeBaseConnection {
       let headers: Http.OutgoingHttpHeaders
       if (isCredentialsAuth(params?.auth)) {
         headers = {
-          ...this.defaultHeaders,
+          ...this.defaultHeadersWithOverride(params),
           'X-ClickHouse-User': params.auth.username,
           'X-ClickHouse-Key': params.auth.password,
         }
       } else {
         headers = {
-          ...this.defaultHeaders,
+          ...this.defaultHeadersWithOverride(params),
           'X-ClickHouse-User': this.params.auth.username,
           'X-ClickHouse-Key': this.params.auth.password,
         }

--- a/packages/client-web/__tests__/integration/web_client.test.ts
+++ b/packages/client-web/__tests__/integration/web_client.test.ts
@@ -1,5 +1,5 @@
+import { getHeadersTestParams } from '@test/utils/parametrized'
 import { createClient } from '../../src'
-import type { WebClickHouseClient } from '../../src/client'
 
 describe('[Web] Client', () => {
   let fetchSpy: jasmine.Spy<typeof window.fetch>
@@ -16,46 +16,85 @@ describe('[Web] Client', () => {
           'Test-Header': 'foobar',
         },
       })
-      const fetchParams = await pingAndGetRequestInit(client)
+      await client.ping()
+      const fetchParams = getFetchRequestInit()
       expect(fetchParams!.headers).toEqual({
-        Authorization: 'Basic ZGVmYXVsdDo=', // default user with empty password
+        ...defaultHeaders,
         'Test-Header': 'foobar',
       })
     })
 
     it('should work with no additional HTTP headers provided', async () => {
       const client = createClient({})
-      const fetchParams = await pingAndGetRequestInit(client)
-      expect(fetchParams!.headers).toEqual({
-        Authorization: 'Basic ZGVmYXVsdDo=', // default user with empty password
+      await client.ping()
+      const fetchParams = getFetchRequestInit()
+      expect(fetchParams!.headers).toEqual(defaultHeaders)
+    })
+
+    it('should work with additional HTTP headers on the method level', async () => {
+      const client = createClient({
+        http_headers: {
+          FromInstance: 'foo',
+        },
       })
+
+      let fetchCalls = 1
+      const testParams = getHeadersTestParams(client)
+      for (const param of testParams) {
+        await param.methodCall({ FromMethod: 'bar' })
+        expect(getFetchRequestInit(fetchCalls++).headers)
+          .withContext(
+            `${param.methodName}: merges custom HTTP headers from both method and instance`,
+          )
+          .toEqual({
+            ...defaultHeaders,
+            FromInstance: 'foo',
+            FromMethod: 'bar',
+          })
+
+        await param.methodCall({ FromInstance: 'bar' })
+        expect(getFetchRequestInit(fetchCalls++).headers)
+          .withContext(
+            `${param.methodName}: overrides HTTP headers from the instance with the values from the method call`,
+          )
+          .toEqual({
+            ...defaultHeaders,
+            FromInstance: 'bar',
+          })
+      }
     })
   })
 
   describe('KeepAlive setting', () => {
     it('should be enabled by default', async () => {
       const client = createClient()
-      const fetchParams = await pingAndGetRequestInit(client)
+      await client.ping()
+      const fetchParams = getFetchRequestInit()
       expect(fetchParams.keepalive).toBeTruthy()
     })
 
     it('should be possible to disable it', async () => {
       const client = createClient({ keep_alive: { enabled: false } })
-      const fetchParams = await pingAndGetRequestInit(client)
+      await client.ping()
+      const fetchParams = getFetchRequestInit()
       expect(fetchParams!.keepalive).toBeFalsy()
     })
 
     it('should be enabled with an explicit setting', async () => {
       const client = createClient({ keep_alive: { enabled: true } })
-      const fetchParams = await pingAndGetRequestInit(client)
+      await client.ping()
+      const fetchParams = getFetchRequestInit()
       expect(fetchParams.keepalive).toBeTruthy()
     })
   })
 
-  async function pingAndGetRequestInit(client: WebClickHouseClient) {
-    await client.ping()
-    expect(fetchSpy).toHaveBeenCalledTimes(1)
-    const [, fetchParams] = fetchSpy.calls.mostRecent().args
-    return fetchParams!
+  function getFetchRequestInit(fetchSpyCalledTimes: number = 1) {
+    expect(fetchSpy).toHaveBeenCalledTimes(fetchSpyCalledTimes)
+    const [, requestInit] = fetchSpy.calls.mostRecent().args
+    return requestInit!
+  }
+
+  const defaultHeaders = {
+    Authorization: 'Basic ZGVmYXVsdDo=', // default user with empty password
   }
 })

--- a/packages/client-web/__tests__/integration/web_client.test.ts
+++ b/packages/client-web/__tests__/integration/web_client.test.ts
@@ -14,6 +14,7 @@ describe('[Web] Client', () => {
       const client = createClient({
         http_headers: {
           'Test-Header': 'foobar',
+          Authorization: 'should-be-overridden-by-client-anyway',
         },
       })
       await client.ping()
@@ -35,6 +36,7 @@ describe('[Web] Client', () => {
       const client = createClient({
         http_headers: {
           FromInstance: 'foo',
+          Authorization: 'should-be-overridden-by-client-anyway',
         },
       })
 

--- a/packages/client-web/src/connection/web_connection.ts
+++ b/packages/client-web/src/connection/web_connection.ts
@@ -31,18 +31,12 @@ type WebInsertParams<T> = Omit<
 export type WebConnectionParams = ConnectionParams
 
 export class WebConnection implements Connection<ReadableStream> {
-  private readonly defaultHeaders: Record<string, string>
+  private readonly defaultAuthHeader: string
   constructor(private readonly params: WebConnectionParams) {
     if (params.auth.type === 'JWT') {
-      this.defaultHeaders = {
-        Authorization: `Bearer ${params.auth.access_token}`,
-        ...params?.http_headers,
-      }
+      this.defaultAuthHeader = `Bearer ${params.auth.access_token}`
     } else if (params.auth.type === 'Credentials') {
-      this.defaultHeaders = {
-        Authorization: `Basic ${btoa(`${params.auth.username}:${params.auth.password}`)}`,
-        ...params?.http_headers,
-      }
+      this.defaultAuthHeader = `Basic ${btoa(`${params.auth.username}:${params.auth.password}`)}`
     } else {
       throw new Error(`Unknown auth type: ${(params.auth as any).type}`)
     }
@@ -184,15 +178,9 @@ export class WebConnection implements Connection<ReadableStream> {
     }
 
     try {
-      const authHeaderOverride = getAuthHeaderOverride(params?.auth)
       const headers = withCompressionHeaders({
-        headers:
-          authHeaderOverride !== undefined
-            ? {
-                ...this.defaultHeaders,
-                Authorization: authHeaderOverride,
-              }
-            : this.defaultHeaders,
+        headers: this.defaultHeadersWithOverride(params),
+        // It is not currently working as expected in all major browsers
         enable_request_compression: false,
         enable_response_compression:
           this.params.compression.decompress_response,
@@ -252,6 +240,26 @@ export class WebConnection implements Connection<ReadableStream> {
       query_id,
     }
   }
+
+  private defaultHeadersWithOverride(
+    params?: ConnBaseQueryParams,
+  ): Record<string, string> {
+    let authHeader: string
+    if (isJWTAuth(params?.auth)) {
+      authHeader = `Bearer ${params?.auth.access_token}`
+    } else if (isCredentialsAuth(params?.auth)) {
+      authHeader = `Basic ${btoa(`${params?.auth.username}:${params?.auth.password}`)}`
+    } else {
+      authHeader = this.defaultAuthHeader
+    }
+    return {
+      // Custom HTTP headers from the client configuration
+      ...(this.params.http_headers ?? {}),
+      // Custom HTTP headers for this particular request; it will override the client configuration with the same keys
+      ...(params?.http_headers ?? {}),
+      Authorization: authHeader,
+    }
+  }
 }
 
 function getQueryId(query_id: string | undefined): string {
@@ -264,15 +272,6 @@ function getResponseHeaders(response: Response): ResponseHeaders {
     headers[key] = value
   })
   return headers
-}
-
-function getAuthHeaderOverride(auth: ConnBaseQueryParams['auth']) {
-  if (isJWTAuth(auth)) {
-    return `Bearer ${auth.access_token}`
-  }
-  if (isCredentialsAuth(auth)) {
-    return `Basic ${btoa(`${auth.username}:${auth.password}`)}`
-  }
 }
 
 interface RunExecResult {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,7 +19,7 @@
     "importHelpers": false,
     "outDir": "out",
     "lib": ["esnext", "dom"],
-    "types": ["node", "jest", "jasmine"],
+    "types": ["node", "jasmine"],
     "baseUrl": "./",
     "paths": {
       "@clickhouse/client-common": ["packages/client-common/src/index.ts"]


### PR DESCRIPTION
## Summary

Based on #395; allows to override the HTTP headers on the method level for both Node.js and Web implementations. 

Closes #394, as it will be possible to specify the headers as follows:

```ts
const resultSet = await client.query({
  http_headers: {
    traceparent: '...',
    tracestate: '...',
  },
)
```


## Checklist
- [x] Unit and integration tests covering the common scenarios were added
- [x] A human-readable description of the changes was provided to include in CHANGELOG
