### PR TITLE
Support 32-bit architecture in stream

### DIFF
--- a/packages/client-node/src/utils/stream.ts
+++ b/packages/client-node/src/utils/stream.ts
@@ -3,8 +3,15 @@ import { constants } from 'buffer'
 
 const { MAX_STRING_LENGTH } = constants
 
-export function isStream(obj: any): obj is Stream.Readable {
-  return obj !== null && typeof obj.pipe === 'function'
+export function isStream(obj: unknown): obj is Stream.Readable {
+  return (
+    typeof obj === 'object' &&
+    obj !== null &&
+    'pipe' in obj &&
+    typeof obj.pipe === 'function' &&
+    'on' in obj &&
+    typeof obj.on === 'function'
+  )
 }
 
 export async function getAsText(stream: Stream.Readable): Promise<string> {

--- a/packages/client-node/src/utils/stream.ts
+++ b/packages/client-node/src/utils/stream.ts
@@ -1,7 +1,7 @@
 import Stream from 'stream'
+import { constants } from 'buffer'
 
-// See https://github.com/v8/v8/commit/ea56bf5513d0cbd2a35a9035c5c2996272b8b728
-const MaxStringLength = Math.pow(2, 29) - 24
+const { MAX_STRING_LENGTH } = constants
 
 export function isStream(obj: any): obj is Stream.Readable {
   return obj !== null && typeof obj.pipe === 'function'
@@ -13,10 +13,10 @@ export async function getAsText(stream: Stream.Readable): Promise<string> {
   const textDecoder = new TextDecoder()
   for await (const chunk of stream) {
     const decoded = textDecoder.decode(chunk, { stream: true })
-    if (decoded.length + text.length > MaxStringLength) {
+    if (decoded.length + text.length > MAX_STRING_LENGTH) {
       throw new Error(
         'The response length exceeds the maximum allowed size of V8 String: ' +
-          `${MaxStringLength}; consider limiting the amount of requested rows.`,
+          `${MAX_STRING_LENGTH}; consider limiting the amount of requested rows.`,
       )
     }
     text += decoded


### PR DESCRIPTION
## Summary
The PR introduces two improvements related to the `stream` utility:

1. Replaces the hardcoded value with the `MAX_STRING_LENGTH` constant from [node.buffer](https://nodejs.org/api/buffer.html#bufferconstantsmax_string_length). The issue with the hardcoded value is that it doesn't account for 32-bit architectures and the function couldn't detect the limit.
2. Replaces the use of `any` with `unknown` in the `isStream` function.

I didn't add tests since the main flow remains unchanged, and the update addresses 32-bit architectures only. 