### PR TITLE
Update `os_cpu_busy_time_threshold` to avoid `SERVER_OVERLOADED` error locally

### DIFF
--- a/.docker/clickhouse/cluster/server1_config.xml
+++ b/.docker/clickhouse/cluster/server1_config.xml
@@ -116,4 +116,7 @@
       <path>users.xml</path>
     </users_xml>
   </user_directories>
+
+  <!-- Avoid SERVER_OVERLOADED running many parallel tests after 25.5+ -->
+  <os_cpu_busy_time_threshold>1000000000000000000</os_cpu_busy_time_threshold>
 </clickhouse>

--- a/.docker/clickhouse/cluster/server2_config.xml
+++ b/.docker/clickhouse/cluster/server2_config.xml
@@ -116,4 +116,7 @@
       <path>users.xml</path>
     </users_xml>
   </user_directories>
+
+  <!-- Avoid SERVER_OVERLOADED running many parallel tests after 25.5+ -->
+  <os_cpu_busy_time_threshold>1000000000000000000</os_cpu_busy_time_threshold>
 </clickhouse>

--- a/.docker/clickhouse/single_node/config.xml
+++ b/.docker/clickhouse/single_node/config.xml
@@ -58,4 +58,7 @@
       <path>users.xml</path>
     </users_xml>
   </user_directories>
+
+  <!-- Avoid SERVER_OVERLOADED running many parallel tests after 25.5+ -->
+  <os_cpu_busy_time_threshold>1000000000000000000</os_cpu_busy_time_threshold>
 </clickhouse>

--- a/.docker/clickhouse/single_node_tls/config.xml
+++ b/.docker/clickhouse/single_node_tls/config.xml
@@ -51,4 +51,7 @@
       <path>users.xml</path>
     </users_xml>
   </user_directories>
+
+  <!-- Avoid SERVER_OVERLOADED running many parallel tests after 25.5+ -->
+  <os_cpu_busy_time_threshold>1000000000000000000</os_cpu_busy_time_threshold>
 </clickhouse>


### PR DESCRIPTION
## Summary

Fixes an occasional CI failure with the current `head` build.
