### PR TITLE
Add an arbitrary format insert streaming example using Avro

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -43,6 +43,7 @@ If something is missing, or you found a mistake in one of these examples, please
 - [insert_file_stream_csv.ts](node/insert_file_stream_csv.ts) - (Node.js only) stream a CSV file into ClickHouse.
 - [insert_file_stream_ndjson.ts](node/insert_file_stream_ndjson.ts) - (Node.js only) stream a NDJSON file into ClickHouse.
 - [insert_file_stream_parquet.ts](node/insert_file_stream_parquet.ts) - (Node.js only) stream a Parquet file into ClickHouse.
+- [insert_arbitrary_format_stream.ts](node/insert_arbitrary_format_stream.ts) - (Node.js only) stream in arbitrary format into ClickHouse. In this case, the input format is [AVRO](https://clickhouse.com/docs/interfaces/formats/Avro), inserting the data from an Avro data file generated ad-hoc.
 - [stream_created_from_array_raw.ts](node/stream_created_from_array_raw.ts) - (Node.js only) converting the string input into a stream and sending it to ClickHouse; in this scenario, the base input is a CSV string.
 - [insert_values_and_functions.ts](insert_values_and_functions.ts) - generating an `INSERT INTO ... VALUES` statement that uses a combination of values and function calls.
 - [insert_ephemeral_columns.ts](insert_ephemeral_columns.ts) - inserting data into a table that has [ephemeral columns](https://clickhouse.com/docs/en/sql-reference/statements/create/table#ephemeral).

--- a/examples/node/.gitignore
+++ b/examples/node/.gitignore
@@ -1,0 +1,1 @@
+resources/data.avro

--- a/examples/node/insert_arbitrary_format_stream.ts
+++ b/examples/node/insert_arbitrary_format_stream.ts
@@ -1,0 +1,95 @@
+import type { ClickHouseClient } from '@clickhouse/client'
+import { createClient, drainStream } from '@clickhouse/client'
+import * as avro from 'avsc'
+import Fs from 'fs'
+import { cwd } from 'node:process'
+import Path from 'path'
+
+/** If a particular format is not supported in the {@link ClickHouseClient.insert} method, there is still a workaround:
+ *  you could use the {@link ClickHouseClient.exec} method to insert data in an arbitrary format.
+ *  In this scenario, we are inserting the data from a stream in AVRO format.
+ *  Related issue with a question: https://github.com/ClickHouse/clickhouse-js/issues/418 */
+
+void (async () => {
+  const client = createClient()
+  const tableName = 'chjs_avro_stream_insert_demo'
+  await prepareTable(client, tableName)
+
+  const avroDataFilePath = Path.resolve(cwd(), './node/resources/data.avro')
+  const avroStream = await getAvroDataFileStream(avroDataFilePath)
+
+  // Important #1: remember to add the FORMAT clause here, as `exec` takes a raw query in the arguments!
+  const execResult = await client.exec({
+    query: `INSERT INTO ${tableName} FORMAT Avro`,
+    values: avroStream,
+  })
+
+  // Important #2: the result stream contains nothing useful for an INSERT query (usually, it is just `Ok.`),
+  // and should be immediately drained to release the underlying connection (i.e., HTTP keep-alive socket).
+  await drainStream(execResult.stream)
+
+  // Verifying that the data was properly inserted; using `JSONEachRow` output format for convenience
+  const rs = await client.query({
+    query: `SELECT * FROM ${tableName}`,
+    format: 'JSONEachRow',
+  })
+  console.log('Inserted data:', await rs.json())
+})()
+
+async function prepareTable(client: ClickHouseClient, tableName: string) {
+  await client.command({
+    query: `
+      CREATE OR REPLACE TABLE ${tableName}
+      (id Int32, name String, email String, isActive Boolean)
+      ENGINE MergeTree()
+      ORDER BY (id)
+    `,
+    clickhouse_settings: {
+      // If on cluster: wait until the changes are applied on all nodes.
+      // See https://clickhouse.com/docs/en/interfaces/http/#response-buffering
+      wait_end_of_query: 1,
+    },
+  })
+}
+
+// A simple AVRO data file stream generator for the sake of this example.
+// See also: https://clickhouse.com/docs/interfaces/formats/Avro#inserting-data
+async function getAvroDataFileStream(filePath: string) {
+  const userSchema: avro.Schema = {
+    type: 'record',
+    name: 'User',
+    fields: [
+      { name: 'id', type: 'int' },
+      { name: 'name', type: 'string' },
+      { name: 'email', type: 'string' },
+      { name: 'isActive', type: 'boolean' },
+    ],
+  }
+  const userEncoder = avro.createFileEncoder(filePath, userSchema)
+  const users = [
+    {
+      id: 1001,
+      name: 'Jane Smith',
+      email: 'jane.smith@example.com',
+      isActive: true,
+    },
+    {
+      id: 1002,
+      name: 'John Doe',
+      email: 'john.doe@unknown.com',
+      isActive: false,
+    },
+  ]
+
+  for (const user of users) {
+    userEncoder.write(user)
+  }
+
+  // Wait until the data is flushed to the file
+  await new Promise((resolve, reject) => {
+    userEncoder.end(() => resolve(true))
+    userEncoder.on('error', reject)
+  })
+
+  return Fs.createReadStream(filePath)
+}

--- a/examples/package.json
+++ b/examples/package.json
@@ -15,6 +15,7 @@
     "@clickhouse/client": "latest"
   },
   "devDependencies": {
+    "avsc": "^5.7.7",
     "set-interval-async": "^3.0.3",
     "split2": "^4.2.0",
     "ts-node": "^10.9.1"


### PR DESCRIPTION
## Summary

Closes #418 - adds an extended example of `exec` usage with `values` from https://github.com/ClickHouse/clickhouse-js/pull/290.
