### PR TITLE
chore(types): add missing `allow_experimental_join_condition` to `ClickHouseServerSettings`

### DIFF
--- a/packages/client-common/src/settings.ts
+++ b/packages/client-common/src/settings.ts
@@ -77,6 +77,8 @@ interface ClickHouseServerSettings {
   allow_experimental_undrop_table_query?: Bool
   /** Enable WINDOW VIEW. Not mature enough. */
   allow_experimental_window_view?: Bool
+  /** Support join with inequal conditions which involve columns from both left and right table. e.g. t1.y < t2.y. */
+  allow_experimental_join_condition?: Bool
   /** Allow functions that use Hyperscan library. Disable to avoid potentially long compilation times and excessive resource usage. */
   allow_hyperscan?: Bool
   /** Allow functions for introspection of ELF and DWARF for query profiling. These functions are slow and may impose security considerations. */


### PR DESCRIPTION
## Summary
Adds `allow_experimental_join_condition` to `ClickHouseServerSettings` for better intellisense.

## Checklist
- [x] A human-readable description of the changes was provided to include in CHANGELOG
