### PR TITLE
Add a warning on a socket closed without fully consuming the stream

### DIFF
--- a/.docker/clickhouse/single_node_tls/Dockerfile
+++ b/.docker/clickhouse/single_node_tls/Dockerfile
@@ -1,4 +1,4 @@
-FROM clickhouse/clickhouse-server:25.2-alpine
+FROM clickhouse/clickhouse-server:25.6-alpine
 COPY .docker/clickhouse/single_node_tls/certificates /etc/clickhouse-server/certs
 RUN chown clickhouse:clickhouse -R /etc/clickhouse-server/certs \
     && chmod 600 /etc/clickhouse-server/certs/* \

--- a/docker-compose.cluster.yml
+++ b/docker-compose.cluster.yml
@@ -2,7 +2,7 @@ version: '2.3'
 
 services:
   clickhouse1:
-    image: 'clickhouse/clickhouse-server:${CLICKHOUSE_VERSION-25.2-alpine}'
+    image: 'clickhouse/clickhouse-server:${CLICKHOUSE_VERSION-25.6-alpine}'
     ulimits:
       nofile:
         soft: 262144
@@ -21,7 +21,7 @@ services:
       - './.docker/clickhouse/users.xml:/etc/clickhouse-server/users.xml'
 
   clickhouse2:
-    image: 'clickhouse/clickhouse-server:${CLICKHOUSE_VERSION-25.2-alpine}'
+    image: 'clickhouse/clickhouse-server:${CLICKHOUSE_VERSION-25.6-alpine}'
     ulimits:
       nofile:
         soft: 262144

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 #version: '3.8'
 services:
   clickhouse:
-    image: 'clickhouse/clickhouse-server:${CLICKHOUSE_VERSION-25.2-alpine}'
+    image: 'clickhouse/clickhouse-server:${CLICKHOUSE_VERSION-25.6-alpine}'
     container_name: 'clickhouse-js-clickhouse-server'
     environment:
       CLICKHOUSE_SKIP_USER_SETUP: 1

--- a/packages/client-common/src/logger.ts
+++ b/packages/client-common/src/logger.ts
@@ -4,7 +4,7 @@ export interface LogParams {
   message: string
   args?: Record<string, unknown>
 }
-export type ErrorLogParams = LogParams & { err: Error }
+export type ErrorLogParams = LogParams & { err?: Error }
 export type WarnLogParams = LogParams & { err?: Error }
 export interface Logger {
   trace(params: LogParams): void
@@ -65,7 +65,9 @@ export class DefaultLogger implements Logger {
     if (args) {
       params.push('\nArguments:', args)
     }
-    params.push('\nCaused by:', err)
+    if (err) {
+      params.push('\nCaused by:', err)
+    }
     console.error(...params)
   }
 }

--- a/packages/client-common/src/logger.ts
+++ b/packages/client-common/src/logger.ts
@@ -4,7 +4,7 @@ export interface LogParams {
   message: string
   args?: Record<string, unknown>
 }
-export type ErrorLogParams = LogParams & { err?: Error }
+export type ErrorLogParams = LogParams & { err: Error }
 export type WarnLogParams = LogParams & { err?: Error }
 export interface Logger {
   trace(params: LogParams): void
@@ -65,9 +65,7 @@ export class DefaultLogger implements Logger {
     if (args) {
       params.push('\nArguments:', args)
     }
-    if (err) {
-      params.push('\nCaused by:', err)
-    }
+    params.push('\nCaused by:', err)
     console.error(...params)
   }
 }

--- a/packages/client-node/src/connection/node_base_connection.ts
+++ b/packages/client-node/src/connection/node_base_connection.ts
@@ -642,8 +642,11 @@ export abstract class NodeBaseConnection
                   message: `Socket ${socketId} was closed or ended, 'free' listener removed`,
                 })
                 if (!responseStream.readableEnded) {
-                  this.logger.error({
-                    message: `${op}: socket was closed or ended before the response was fully read. This can potentially result in an uncaught ECONNRESET error! Consider fully consuming, draining, or destroying the response stream`,
+                  this.logger.warn({
+                    message:
+                      `${op}: socket was closed or ended before the response was fully read. ` +
+                      'This can potentially result in an uncaught ECONNRESET error! ' +
+                      'Consider fully consuming, draining, or destroying the response stream.',
                     args: {
                       query: params.query,
                       query_id:

--- a/packages/client-node/src/connection/node_base_connection.ts
+++ b/packages/client-node/src/connection/node_base_connection.ts
@@ -641,7 +641,7 @@ export abstract class NodeBaseConnection
                 this.logger.trace({
                   message: `Socket ${socketId} was closed or ended, 'free' listener removed`,
                 })
-                if (!responseStream.readableEnded) {
+                if (responseStream && !responseStream.readableEnded) {
                   this.logger.warn({
                     message:
                       `${op}: socket was closed or ended before the response was fully read. ` +


### PR DESCRIPTION
Closes #439 

Adds a warning like this:

```
[2025-07-15T15:28:53.416Z][ERROR][@clickhouse/client][Connection] Query: socket was closed or ended before the response was fully read. This can potentially result in an uncaught ECONNRESET error! Consider fully consuming, draining, or destroying the response stream 
```

Bump ClickHouse to 25.6