### PR TITLE
Add Time/64 examples, update settings typings

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -63,6 +63,7 @@ If something is missing, or you found a mistake in one of these examples, please
 #### Data types
 
 - [dynamic_variant_json.ts](./dynamic_variant_json.ts) - using experimental [Dynamic](https://clickhouse.com/docs/en/sql-reference/data-types/dynamic)/[Variant](https://clickhouse.com/docs/en/sql-reference/data-types/variant)/[JSON](https://clickhouse.com/docs/en/sql-reference/data-types/newjson) data types with [JSONEachRow](https://clickhouse.com/docs/en/interfaces/formats#jsoneachrow) format.
+- [time_time64.ts](./time_time64.ts) - using [Time](https://clickhouse.com/docs/en/sql-reference/data-types/time) and [Time64](https://clickhouse.com/docs/en/sql-reference/data-types/time64) data types with [JSONEachRow](https://clickhouse.com/docs/en/interfaces/formats#jsoneachrow) format (ClickHouse 25.6+).
 
 #### Special cases
 

--- a/examples/time_time64.ts
+++ b/examples/time_time64.ts
@@ -1,0 +1,75 @@
+import { createClient } from '@clickhouse/client' // or '@clickhouse/client-web'
+
+/** See also:
+ *  - https://clickhouse.com/docs/sql-reference/data-types/time
+ *  - https://clickhouse.com/docs/sql-reference/data-types/time64 */
+void (async () => {
+  const tableName = `chjs_time_time64`
+  const client = createClient({
+    clickhouse_settings: {
+      // Since ClickHouse 25.6
+      enable_time_time64_type: 1,
+    },
+  })
+  await client.command({
+    query: `
+      CREATE OR REPLACE TABLE ${tableName}
+      (
+        id    UInt64,
+        t     Time,
+        t64_0 Time64(0),
+        t64_3 Time64(3),
+        t64_6 Time64(6),
+        t64_9 Time64(9),
+      )
+      ENGINE MergeTree
+      ORDER BY id
+    `,
+  })
+  // Sample representation in JSONEachRow format
+  const values = [
+    {
+      id: 1,
+      t: '12:34:56',
+      t64_0: '12:34:56',
+      t64_3: '12:34:56.123',
+      t64_6: '12:34:56.123456',
+      t64_9: '12:34:56.123456789',
+    },
+    {
+      id: 2,
+      t: '23:59:59',
+      t64_0: '23:59:59',
+      t64_3: '23:59:59.987',
+      t64_6: '23:59:59.987654',
+      t64_9: '23:59:59.987654321',
+    },
+    {
+      id: 3,
+      t: '999:59:59',
+      t64_0: '999:59:59',
+      t64_3: '999:59:59.999',
+      t64_6: '999:59:59.999999',
+      t64_9: '999:59:59.999999999',
+    },
+    {
+      id: 4,
+      t: '-999:59:59',
+      t64_0: '-999:59:59',
+      t64_3: '-999:59:59.999',
+      t64_6: '-999:59:59.999999',
+      t64_9: '-999:59:59.999999999',
+    },
+  ]
+  await client.insert({
+    table: tableName,
+    format: 'JSONEachRow',
+    values,
+  })
+  const rs = await client.query({
+    query: `SELECT * FROM ${tableName}`,
+    format: 'JSONEachRow',
+  })
+  console.log(await rs.json())
+  await client.close()
+})()

--- a/packages/client-common/src/settings.ts
+++ b/packages/client-common/src/settings.ts
@@ -79,6 +79,16 @@ interface ClickHouseServerSettings {
   allow_experimental_window_view?: Bool
   /** Support join with inequal conditions which involve columns from both left and right table. e.g. t1.y < t2.y. */
   allow_experimental_join_condition?: Bool
+  /** Since ClickHouse 24.1 */
+  allow_experimental_variant_type: Bool
+  /** Since ClickHouse 24.5 */
+  allow_experimental_dynamic_type: Bool
+  /** Since ClickHouse 24.8 */
+  allow_experimental_json_type: Bool
+  /** Since ClickHouse 25.3 */
+  enable_json_type: Bool
+  /** Since ClickHouse 25.6 */
+  enable_time_time64_type: Bool
   /** Allow functions that use Hyperscan library. Disable to avoid potentially long compilation times and excessive resource usage. */
   allow_hyperscan?: Bool
   /** Allow functions for introspection of ELF and DWARF for query profiling. These functions are slow and may impose security considerations. */
@@ -1613,16 +1623,6 @@ export type ClickHouseSettings = Partial<ClickHouseServerSettings> &
   Record<string, number | string | boolean | SettingsMap | undefined>
 
 export interface MergeTreeSettings {
-  /** Since ClickHouse 24.1 */
-  allow_experimental_variant_type: Bool
-  /** Since ClickHouse 24.5 */
-  allow_experimental_dynamic_type: Bool
-  /** Since ClickHouse 24.8 */
-  allow_experimental_json_type: Bool
-  /** Since ClickHouse 25.3 */
-  enable_json_type: Bool
-  /** Since ClickHouse 25.6 */
-  enable_time_time64_type: Bool
   /** Allow floating point as partition key */
   allow_floating_point_partition_key?: Bool
   /** Allow Nullable types as primary keys. */

--- a/packages/client-common/src/settings.ts
+++ b/packages/client-common/src/settings.ts
@@ -1613,6 +1613,16 @@ export type ClickHouseSettings = Partial<ClickHouseServerSettings> &
   Record<string, number | string | boolean | SettingsMap | undefined>
 
 export interface MergeTreeSettings {
+  /** Since ClickHouse 24.1 */
+  allow_experimental_variant_type: Bool
+  /** Since ClickHouse 24.5 */
+  allow_experimental_dynamic_type: Bool
+  /** Since ClickHouse 24.8 */
+  allow_experimental_json_type: Bool
+  /** Since ClickHouse 25.3 */
+  enable_json_type: Bool
+  /** Since ClickHouse 25.6 */
+  enable_time_time64_type: Bool
   /** Allow floating point as partition key */
   allow_floating_point_partition_key?: Bool
   /** Allow Nullable types as primary keys. */

--- a/packages/client-common/src/settings.ts
+++ b/packages/client-common/src/settings.ts
@@ -80,15 +80,15 @@ interface ClickHouseServerSettings {
   /** Support join with inequal conditions which involve columns from both left and right table. e.g. t1.y < t2.y. */
   allow_experimental_join_condition?: Bool
   /** Since ClickHouse 24.1 */
-  allow_experimental_variant_type: Bool
+  allow_experimental_variant_type?: Bool
   /** Since ClickHouse 24.5 */
-  allow_experimental_dynamic_type: Bool
+  allow_experimental_dynamic_type?: Bool
   /** Since ClickHouse 24.8 */
-  allow_experimental_json_type: Bool
+  allow_experimental_json_type?: Bool
   /** Since ClickHouse 25.3 */
-  enable_json_type: Bool
+  enable_json_type?: Bool
   /** Since ClickHouse 25.6 */
-  enable_time_time64_type: Bool
+  enable_time_time64_type?: Bool
   /** Allow functions that use Hyperscan library. Disable to avoid potentially long compilation times and excessive resource usage. */
   allow_hyperscan?: Bool
   /** Allow functions for introspection of ELF and DWARF for query profiling. These functions are slow and may impose security considerations. */


### PR DESCRIPTION
Closes #432 

- Adds a JSONEachRow example with the new time types
- Adds a few missing type hints to the settings definition.