### PR TITLE
Optimize toSearchParams

### DIFF
--- a/packages/client-common/src/utils/url.ts
+++ b/packages/client-common/src/utils/url.ts
@@ -51,45 +51,44 @@ export function toSearchParams({
   query_id,
   role,
 }: ToSearchParamsOptions): URLSearchParams {
-  const params = new URLSearchParams()
-  params.set('query_id', query_id)
+  const entries: [string, string][] = [['query_id', query_id]]
 
   if (query_params !== undefined) {
     for (const [key, value] of Object.entries(query_params)) {
       const formattedParam = formatQueryParams({ value })
-      params.set(`param_${key}`, formattedParam)
+      entries.push([`param_${key}`, formattedParam])
     }
   }
 
   if (clickhouse_settings !== undefined) {
     for (const [key, value] of Object.entries(clickhouse_settings)) {
       if (value !== undefined) {
-        params.set(key, formatQuerySettings(value))
+        entries.push([key, formatQuerySettings(value)])
       }
     }
   }
 
   if (database !== undefined && database !== 'default') {
-    params.set('database', database)
+    entries.push(['database', database])
   }
 
   if (query) {
-    params.set('query', query)
+    entries.push(['query', query])
   }
 
   if (session_id) {
-    params.set('session_id', session_id)
+    entries.push(['session_id', session_id])
   }
 
   if (role) {
     if (typeof role === 'string') {
-      params.set('role', role)
+      entries.push(['role', role])
     } else if (Array.isArray(role)) {
       for (const r of role) {
-        params.append('role', r)
+        entries.push(['role', r])
       }
     }
   }
 
-  return params
+  return new URLSearchParams(entries)
 }


### PR DESCRIPTION
## Summary
I noticed toSearchParams showing up in profiles. I wrote a benchmarking script that revealed it had super-linear run times as the number of params grew: 

```
--- Benchmarking with 10 params ---
Original: 0.08ms per iteration
Optimized: 0.09ms per iteration

--- Benchmarking with 100 params ---
Original: 0.37ms per iteration
Optimized: 0.06ms per iteration

--- Benchmarking with 1000 params ---
Original: 6.62ms per iteration
Optimized: 0.72ms per iteration

--- Benchmarking with 10000 params ---
Original: 602.41ms per iteration
Optimized: 13.18ms per iteration

--- Benchmarking with 100000 params ---
Original: 50449.80ms per iteration
Optimized: 224.65ms per iteration
```

## Checklist
Delete items not relevant to your PR:
- [ ] Unit and integration tests covering the common scenarios were added
- [ ] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
