### PR TITLE
Update ClickHouse JS client Node.js version support table

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,7 @@ and help us maintain up-to-date documentation.
 
 You have installed:
 
-- a compatible LTS version of Node.js: `v16.x`, `v18.x` or `v20.x`
+- a compatible LTS version of Node.js: `v20.x`, `v22.x` or `v24.x`
 - NPM >= `9.x`
 
 ### Create a fork of the repository and clone it


### PR DESCRIPTION
## Summary

According to the [test workflow matrix](https://github.com/ClickHouse/clickhouse-js/blob/c8e1d05dcc68e5958e893fa9b8c77ad935900bc9/.github/workflows/tests.yml#L30) the current supported versions are 20, 22 and 24. Updating the docs accordingly.
