### PR TITLE
chore: capitalize error messages in SocketPool for consistency

### DIFF
--- a/packages/client-node/src/connection/socket_pool.ts
+++ b/packages/client-node/src/connection/socket_pool.ts
@@ -544,7 +544,7 @@ export class SocketPool {
         } catch (e) {
           if (log_level <= ClickHouseLogLevel.ERROR) {
             log_writer.error({
-              message: `${op}: an error occurred while housekeeping the idle sockets`,
+              message: `${op}: An error occurred while housekeeping the idle sockets`,
               err: e as Error,
               args: {
                 operation: op,
@@ -686,7 +686,7 @@ export class SocketPool {
         } catch (e) {
           if (log_level <= ClickHouseLogLevel.ERROR) {
             log_writer.error({
-              message: `${op}: an error occurred while ending the request without body`,
+              message: `${op}: An error occurred while ending the request without body`,
               err: e as Error,
               args: {
                 operation: op,


### PR DESCRIPTION
Two log_writer.error messages in SocketPool started with lowercase "an error occurred...", while the third call (line 644, "An error occurred while destroying the request") and the equivalent message in connection/compression.ts use capitalized "An". Align the two outliers for in-file consistency.

## Summary

A short description of the changes with a link to an open issue.

## Checklist

Delete items not relevant to your PR:

- [ ] Unit and integration tests covering the common scenarios were added
- [ ] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
