### PR TITLE
feat: add Codex metadata for Node.js skills

### DIFF
--- a/skills/clickhouse-js-node-coding/.codex-plugin/plugin.json
+++ b/skills/clickhouse-js-node-coding/.codex-plugin/plugin.json
@@ -1,0 +1,28 @@
+{
+  "name": "clickhouse-js-node-coding",
+  "version": "0.1.0",
+  "description": "Write idiomatic application code with the ClickHouse Node.js client (@clickhouse/client): configuration, inserts, selects, query parameters, sessions, and modern data types.",
+  "author": {
+    "name": "ClickHouse Inc",
+    "url": "https://clickhouse.com"
+  },
+  "homepage": "https://clickhouse.com/docs/integrations/javascript",
+  "repository": "https://github.com/ClickHouse/clickhouse-js",
+  "license": "Apache-2.0",
+  "keywords": ["clickhouse", "javascript", "nodejs", "client", "database"],
+  "skills": "./",
+  "interface": {
+    "displayName": "ClickHouse JS Node Coding",
+    "shortDescription": "Write application code with @clickhouse/client.",
+    "longDescription": "Use ClickHouse JS Node Coding for idiomatic Node.js client usage, including client configuration, inserts, selects, formats, query parameters, sessions, and modern ClickHouse data types.",
+    "developerName": "ClickHouse Inc",
+    "category": "Database",
+    "capabilities": ["Read"],
+    "websiteURL": "https://clickhouse.com/docs/integrations/javascript",
+    "defaultPrompt": [
+      "Write Node.js code using the ClickHouse client.",
+      "Show how to query ClickHouse from Node.js."
+    ],
+    "brandColor": "#FFCC01"
+  }
+}

--- a/skills/clickhouse-js-node-troubleshooting/.codex-plugin/plugin.json
+++ b/skills/clickhouse-js-node-troubleshooting/.codex-plugin/plugin.json
@@ -1,0 +1,34 @@
+{
+  "name": "clickhouse-js-node-troubleshooting",
+  "version": "0.1.0",
+  "description": "Troubleshoot common issues with the ClickHouse Node.js client (@clickhouse/client): socket hang-up errors, ECONNRESET, type mismatches, read-only users, proxy paths, TLS, compression, logging, and query parameters.",
+  "author": {
+    "name": "ClickHouse Inc",
+    "url": "https://clickhouse.com"
+  },
+  "homepage": "https://clickhouse.com/docs/integrations/javascript",
+  "repository": "https://github.com/ClickHouse/clickhouse-js",
+  "license": "Apache-2.0",
+  "keywords": [
+    "clickhouse",
+    "javascript",
+    "nodejs",
+    "client",
+    "troubleshooting"
+  ],
+  "skills": "./",
+  "interface": {
+    "displayName": "ClickHouse JS Node Troubleshooting",
+    "shortDescription": "Troubleshoot @clickhouse/client Node.js issues.",
+    "longDescription": "Use ClickHouse JS Node Troubleshooting for Node.js client failures such as socket hang-ups, ECONNRESET, type mismatches, read-only user compression issues, proxy/pathname confusion, TLS errors, logging gaps, and query parameter problems.",
+    "developerName": "ClickHouse Inc",
+    "category": "Database",
+    "capabilities": ["Read"],
+    "websiteURL": "https://clickhouse.com/docs/integrations/javascript",
+    "defaultPrompt": [
+      "Troubleshoot this ClickHouse Node.js client error.",
+      "Diagnose why @clickhouse/client is failing in Node.js."
+    ],
+    "brandColor": "#FFCC01"
+  }
+}

--- a/tests/e2e/skills/check.js
+++ b/tests/e2e/skills/check.js
@@ -47,6 +47,10 @@ const expectedSkills = fs
   .map((d) => d.name)
   .sort()
 
+function readJson(file) {
+  return JSON.parse(fs.readFileSync(file, 'utf8'))
+}
+
 check('repo skills/ directory contains at least one skill', () => {
   assert.ok(
     expectedSkills.length > 0,
@@ -54,11 +58,32 @@ check('repo skills/ directory contains at least one skill', () => {
   )
 })
 
+for (const skill of expectedSkills) {
+  check(`repo skill "${skill}" has Codex plugin metadata`, () => {
+    const manifestPath = path.join(skillsSrcDir, skill, '.codex-plugin', 'plugin.json')
+    assert.ok(
+      fs.existsSync(manifestPath),
+      `expected Codex plugin manifest at ${manifestPath}`,
+    )
+
+    const manifest = readJson(manifestPath)
+    assert.strictEqual(manifest.name, skill)
+    assert.strictEqual(manifest.skills, './')
+    assert.strictEqual(
+      manifest.interface?.category,
+      'Database',
+      `${skill} should use Database install-surface category`,
+    )
+    assert.ok(
+      fs.existsSync(path.join(skillsSrcDir, skill, manifest.skills, 'SKILL.md')),
+      `${skill} Codex skills path should resolve to SKILL.md`,
+    )
+  })
+}
+
 // @clickhouse/client (Node.js) — ships every skill from the repo `skills/` tree.
 const nodeRoot = path.join(nm, '@clickhouse', 'client')
-const nodePkg = JSON.parse(
-  fs.readFileSync(path.join(nodeRoot, 'package.json'), 'utf8'),
-)
+const nodePkg = readJson(path.join(nodeRoot, 'package.json'))
 const declaredSkills = Array.isArray(nodePkg.agents?.skills)
   ? nodePkg.agents.skills
   : []
@@ -100,6 +125,10 @@ for (const skill of declaredSkills) {
       assert.ok(
         fs.existsSync(path.join(resolved, 'SKILL.md')),
         `declared skill at ${skill.path} should contain SKILL.md`,
+      )
+      assert.ok(
+        fs.existsSync(path.join(resolved, '.codex-plugin', 'plugin.json')),
+        `declared skill at ${skill.path} should include Codex plugin metadata`,
       )
     },
   )


### PR DESCRIPTION
## Summary
- add Codex plugin manifests for the Node.js coding and troubleshooting skills
- extend the skills E2E check so packaged skills must include Codex metadata

## Validation
- `npm ci`
- `npm --workspaces run build`
- `npm --workspaces --if-present run pack`
- installed packed packages in `tests/e2e/skills`
- `node check.js`
