### PR TITLE
Fix CI after the `ResultSet` consumption fix

### DIFF
--- a/packages/client-node/__tests__/integration/node_select_streaming.test.ts
+++ b/packages/client-node/__tests__/integration/node_select_streaming.test.ts
@@ -13,11 +13,6 @@ describe('[Node.js] SELECT streaming', () => {
   })
 
   describe('consume the response only once', () => {
-    async function assertAlreadyConsumed$<T>(fn: () => Promise<T>) {
-      await expect(fn()).rejects.toMatchObject({
-        message: 'Stream has been already consumed',
-      })
-    }
     function assertAlreadyConsumed<T>(fn: () => T) {
       expect(fn).toThrow('Stream has been already consumed')
     }
@@ -28,8 +23,12 @@ describe('[Node.js] SELECT streaming', () => {
       })
       expect(await rs.json()).toEqual([{ number: '0' }])
       // wrap in a func to avoid changing inner "this"
-      await assertAlreadyConsumed$(() => rs.json())
-      await assertAlreadyConsumed$(() => rs.text())
+      await expect(() => rs.json()).rejects.toMatchObject({
+        message: 'Stream has been already consumed',
+      })
+      await expect(() => rs.text()).rejects.toMatchObject({
+        message: 'Stream has been already consumed',
+      })
       assertAlreadyConsumed(() => rs.stream())
     })
 
@@ -40,8 +39,12 @@ describe('[Node.js] SELECT streaming', () => {
       })
       expect(await rs.text()).toEqual('0\n')
       // wrap in a func to avoid changing inner "this"
-      await assertAlreadyConsumed$(() => rs.json())
-      await assertAlreadyConsumed$(() => rs.text())
+      await expect(() => rs.json()).rejects.toMatchObject({
+        message: 'Stream has been already consumed',
+      })
+      await expect(() => rs.text()).rejects.toMatchObject({
+        message: 'Stream has been already consumed',
+      })
       assertAlreadyConsumed(() => rs.stream())
     })
 
@@ -58,9 +61,15 @@ describe('[Node.js] SELECT streaming', () => {
       }
       expect(result).toEqual('0')
       // wrap in a func to avoid changing inner "this"
-      await assertAlreadyConsumed$(() => rs.json())
-      await assertAlreadyConsumed$(() => rs.text())
-      assertAlreadyConsumed(() => rs.stream())
+      await expect(() => rs.json()).rejects.toMatchObject({
+        message: 'Stream has been already consumed',
+      })
+      await expect(() => rs.text()).rejects.toMatchObject({
+        message: 'Stream has been already consumed',
+      })
+      await expect(() => rs.stream()).rejects.toMatchObject({
+        message: 'Stream has been already consumed',
+      })
     })
   })
 

--- a/packages/client-node/__tests__/integration/node_select_streaming.test.ts
+++ b/packages/client-node/__tests__/integration/node_select_streaming.test.ts
@@ -29,7 +29,7 @@ describe('[Node.js] SELECT streaming', () => {
       await expect(rs.text()).rejects.toThrow(
         /Stream has been already consumed/,
       )
-      await expect(rs.stream()).rejects.toThrow(
+      await expect(async () => rs.stream()).rejects.toThrow(
         /Stream has been already consumed/,
       )
     })
@@ -47,7 +47,7 @@ describe('[Node.js] SELECT streaming', () => {
       await expect(rs.text()).rejects.toThrow(
         /Stream has been already consumed/,
       )
-      await expect(rs.stream()).rejects.toThrow(
+      await expect(async () => rs.stream()).rejects.toThrow(
         /Stream has been already consumed/,
       )
     })
@@ -71,7 +71,7 @@ describe('[Node.js] SELECT streaming', () => {
       await expect(rs.text()).rejects.toThrow(
         /Stream has been already consumed/,
       )
-      await expect(rs.stream()).rejects.toThrow(
+      await expect(async () => rs.stream()).rejects.toThrow(
         /Stream has been already consumed/,
       )
     })
@@ -84,7 +84,7 @@ describe('[Node.js] SELECT streaming', () => {
         format: 'JSON',
       })
       try {
-        await expect(result.stream()).rejects.toThrow(
+        await expect(async () => result.stream()).rejects.toThrow(
           /JSON format is not streamable/,
         )
       } finally {

--- a/packages/client-node/__tests__/integration/node_select_streaming.test.ts
+++ b/packages/client-node/__tests__/integration/node_select_streaming.test.ts
@@ -37,9 +37,9 @@ describe('[Node.js] SELECT streaming', () => {
     it('should consume a text response only once', async () => {
       const rs = await client.query({
         query: 'SELECT * FROM system.numbers LIMIT 1',
-        format: 'TabSeparated',
+        format: 'JSONEachRow',
       })
-      expect(await rs.text()).toEqual('0\n')
+      expect(await rs.text()).toEqual('{"number":"0"}\n')
       // wrap in a func to avoid changing inner "this"
       await expect(async () => rs.json()).rejects.toThrow(
         /Stream has been already consumed/,
@@ -55,7 +55,7 @@ describe('[Node.js] SELECT streaming', () => {
     it('should consume a stream response only once', async () => {
       const rs = await client.query({
         query: 'SELECT * FROM system.numbers LIMIT 1',
-        format: 'TabSeparated',
+        format: 'JSONEachRow',
       })
       let result = ''
       for await (const rows of rs.stream()) {
@@ -63,7 +63,7 @@ describe('[Node.js] SELECT streaming', () => {
           result += row.text
         })
       }
-      expect(result).toEqual('0')
+      expect(result).toEqual('{"number":"0"}')
       // wrap in a func to avoid changing inner "this"
       await expect(async () => rs.json()).rejects.toThrow(
         /Stream has been already consumed/,
@@ -77,7 +77,7 @@ describe('[Node.js] SELECT streaming', () => {
     })
   })
 
-  describe('select result asStream()', () => {
+  describe('select result as stream()', () => {
     it('throws an exception if format is not stream-able', async () => {
       const result = await client.query({
         query: 'SELECT number FROM system.numbers LIMIT 5',

--- a/packages/client-node/__tests__/integration/node_select_streaming.test.ts
+++ b/packages/client-node/__tests__/integration/node_select_streaming.test.ts
@@ -23,13 +23,13 @@ describe('[Node.js] SELECT streaming', () => {
       })
       expect(await rs.json()).toEqual([{ number: '0' }])
       // wrap in a func to avoid changing inner "this"
-      await expect(async () => rs.json()).rejects.toThrow(
+      await expect(rs.json()).rejects.toThrow(
         /Stream has been already consumed/,
       )
-      await expect(async () => rs.text()).rejects.toThrow(
+      await expect(rs.text()).rejects.toThrow(
         /Stream has been already consumed/,
       )
-      await expect(async () => rs.stream()).rejects.toThrow(
+      await expect(rs.stream()).rejects.toThrow(
         /Stream has been already consumed/,
       )
     })
@@ -41,13 +41,13 @@ describe('[Node.js] SELECT streaming', () => {
       })
       expect(await rs.text()).toEqual('{"number":"0"}\n')
       // wrap in a func to avoid changing inner "this"
-      await expect(async () => rs.json()).rejects.toThrow(
+      await expect(rs.json()).rejects.toThrow(
         /Stream has been already consumed/,
       )
-      await expect(async () => rs.text()).rejects.toThrow(
+      await expect(rs.text()).rejects.toThrow(
         /Stream has been already consumed/,
       )
-      await expect(async () => rs.stream()).rejects.toThrow(
+      await expect(rs.stream()).rejects.toThrow(
         /Stream has been already consumed/,
       )
     })
@@ -65,13 +65,13 @@ describe('[Node.js] SELECT streaming', () => {
       }
       expect(result).toEqual('{"number":"0"}')
       // wrap in a func to avoid changing inner "this"
-      await expect(async () => rs.json()).rejects.toThrow(
+      await expect(rs.json()).rejects.toThrow(
         /Stream has been already consumed/,
       )
-      await expect(async () => rs.text()).rejects.toThrow(
+      await expect(rs.text()).rejects.toThrow(
         /Stream has been already consumed/,
       )
-      await expect(async () => rs.stream()).rejects.toThrow(
+      await expect(rs.stream()).rejects.toThrow(
         /Stream has been already consumed/,
       )
     })
@@ -84,7 +84,7 @@ describe('[Node.js] SELECT streaming', () => {
         format: 'JSON',
       })
       try {
-        await expect(async () => result.stream()).rejects.toThrow(
+        await expect(result.stream()).rejects.toThrow(
           /JSON format is not streamable/,
         )
       } finally {

--- a/packages/client-node/__tests__/integration/node_select_streaming.test.ts
+++ b/packages/client-node/__tests__/integration/node_select_streaming.test.ts
@@ -23,13 +23,15 @@ describe('[Node.js] SELECT streaming', () => {
       })
       expect(await rs.json()).toEqual([{ number: '0' }])
       // wrap in a func to avoid changing inner "this"
-      await expect(() => rs.json()).rejects.toMatchObject({
-        message: 'Stream has been already consumed',
-      })
-      await expect(() => rs.text()).rejects.toMatchObject({
-        message: 'Stream has been already consumed',
-      })
-      assertAlreadyConsumed(() => rs.stream())
+      await expect(async () => rs.json()).rejects.toThrow(
+        /Stream has been already consumed/,
+      )
+      await expect(async () => rs.text()).rejects.toThrow(
+        /Stream has been already consumed/,
+      )
+      await expect(async () => rs.stream()).rejects.toThrow(
+        /Stream has been already consumed/,
+      )
     })
 
     it('should consume a text response only once', async () => {
@@ -39,13 +41,15 @@ describe('[Node.js] SELECT streaming', () => {
       })
       expect(await rs.text()).toEqual('0\n')
       // wrap in a func to avoid changing inner "this"
-      await expect(() => rs.json()).rejects.toMatchObject({
-        message: 'Stream has been already consumed',
-      })
-      await expect(() => rs.text()).rejects.toMatchObject({
-        message: 'Stream has been already consumed',
-      })
-      assertAlreadyConsumed(() => rs.stream())
+      await expect(async () => rs.json()).rejects.toThrow(
+        /Stream has been already consumed/,
+      )
+      await expect(async () => rs.text()).rejects.toThrow(
+        /Stream has been already consumed/,
+      )
+      await expect(async () => rs.stream()).rejects.toThrow(
+        /Stream has been already consumed/,
+      )
     })
 
     it('should consume a stream response only once', async () => {
@@ -61,15 +65,15 @@ describe('[Node.js] SELECT streaming', () => {
       }
       expect(result).toEqual('0')
       // wrap in a func to avoid changing inner "this"
-      await expect(() => rs.json()).rejects.toMatchObject({
-        message: 'Stream has been already consumed',
-      })
-      await expect(() => rs.text()).rejects.toMatchObject({
-        message: 'Stream has been already consumed',
-      })
-      await expect(() => rs.stream()).rejects.toMatchObject({
-        message: 'Stream has been already consumed',
-      })
+      await expect(async () => rs.json()).rejects.toThrow(
+        /Stream has been already consumed/,
+      )
+      await expect(async () => rs.text()).rejects.toThrow(
+        /Stream has been already consumed/,
+      )
+      await expect(async () => rs.stream()).rejects.toThrow(
+        /Stream has been already consumed/,
+      )
     })
   })
 
@@ -80,9 +84,9 @@ describe('[Node.js] SELECT streaming', () => {
         format: 'JSON',
       })
       try {
-        await expect(async () => result.stream()).rejects.toMatchObject({
-          message: expect.stringContaining('JSON format is not streamable'),
-        })
+        await expect(async () => result.stream()).rejects.toThrow(
+          /JSON format is not streamable/,
+        )
       } finally {
         result.close()
       }

--- a/packages/client-node/__tests__/integration/node_stream_error_handling.test.ts
+++ b/packages/client-node/__tests__/integration/node_stream_error_handling.test.ts
@@ -74,4 +74,40 @@ describe('[Node.js] Stream error handling', () => {
 
     assertError(caughtError)
   })
+
+  it.skip('with .json()', async ({ skip }) => {
+    if (!(await isClickHouseVersionAtLeast(client, 25, 11))) {
+      skip()
+    }
+
+    let caughtError: ClickHouseError | null = null
+
+    try {
+      const queryParams = streamErrorQueryParams()
+      const rs = await client.query(queryParams)
+      await rs.json()
+    } catch (err) {
+      caughtError = err as ClickHouseError
+    }
+
+    assertError(caughtError)
+  })
+
+  it.skip('with .text()', async ({ skip }) => {
+    if (!(await isClickHouseVersionAtLeast(client, 25, 11))) {
+      skip()
+    }
+
+    let caughtError: ClickHouseError | null = null
+
+    try {
+      const queryParams = streamErrorQueryParams()
+      const rs = await client.query(queryParams)
+      await rs.text()
+    } catch (err) {
+      caughtError = err as ClickHouseError
+    }
+
+    assertError(caughtError)
+  })
 })

--- a/packages/client-node/src/result_set.ts
+++ b/packages/client-node/src/result_set.ts
@@ -67,6 +67,7 @@ export class ResultSet<
   private readonly exceptionTag: string | undefined = undefined
   private readonly log_error: (error: Error) => void
   private readonly jsonHandling: JSONHandling
+  private _consumed = false
 
   constructor(
     /**
@@ -97,33 +98,38 @@ export class ResultSet<
     }
   }
 
+  private consume() {
+    if (this._consumed) {
+      throw new Error(streamAlreadyConsumedMessage)
+    }
+    this._consumed = true
+    return this._stream
+  }
+
   /** See {@link BaseResultSet.text}. */
   async text(): Promise<string> {
-    if (this._stream.readableEnded) {
-      throw Error(streamAlreadyConsumedMessage)
-    }
-    return await getAsText(this._stream)
+    return await getAsText(this.consume())
   }
 
   /** See {@link BaseResultSet.json}. */
   async json<T>(): Promise<ResultJSONType<T, Format>> {
-    if (this._stream.readableEnded) {
-      throw Error(streamAlreadyConsumedMessage)
-    }
     // JSONEachRow, etc.
     if (isStreamableJSONFamily(this.format as DataFormat)) {
       const result: T[] = []
+      // Using the stream() instead of _stream directly to leverage the existing logic
+      // for handling incomplete chunks and exception tags.
+      // TODO: consider using stream() for all formats to unify the logic and error handling.
       const stream = this.stream<T>()
       for await (const rows of stream) {
         for (const row of rows) {
           result.push(row.json() as T)
         }
       }
-      return result as any
+      return result as ResultJSONType<T, Format>
     }
     // JSON, JSONObjectEachRow, etc.
     if (isNotStreamableJSONFamily(this.format as DataFormat)) {
-      const text = await getAsText(this._stream)
+      const text = await getAsText(this.consume())
       return this.jsonHandling.parse(text)
     }
     // should not be called for CSV, etc.
@@ -132,13 +138,6 @@ export class ResultSet<
 
   /** See {@link BaseResultSet.stream}. */
   stream<T>(): ResultStream<Format, StreamReadable<Row<T, Format>[]>> {
-    // If the underlying stream has already ended by calling `text` or `json`,
-    // Stream.pipeline will create a new empty stream
-    // but without "readableEnded" flag set to true
-    if (this._stream.readableEnded) {
-      throw new Error(streamAlreadyConsumedMessage)
-    }
-
     validateStreamFormat(this.format)
 
     const incompleteChunks: Buffer[] = []
@@ -203,7 +202,7 @@ export class ResultSet<
     })
 
     const pipeline = Stream.pipeline(
-      this._stream,
+      this.consume(),
       toRows,
       function pipelineCb(err) {
         if (
@@ -220,7 +219,7 @@ export class ResultSet<
 
   /** See {@link BaseResultSet.close}. */
   close() {
-    this._stream.destroy(new Error(resultSetClosedMessage))
+    this.consume().destroy(new Error(resultSetClosedMessage))
   }
 
   /**

--- a/packages/client-node/src/result_set.ts
+++ b/packages/client-node/src/result_set.ts
@@ -96,7 +96,7 @@ export class ResultSet<
     if (this._stream.readableEnded) {
       throw Error(streamAlreadyConsumedMessage)
     }
-    return (await getAsText(this._stream)).toString()
+    return await getAsText(this._stream)
   }
 
   /** See {@link BaseResultSet.json}. */

--- a/packages/client-node/src/result_set.ts
+++ b/packages/client-node/src/result_set.ts
@@ -219,7 +219,7 @@ export class ResultSet<
 
   /** See {@link BaseResultSet.close}. */
   close() {
-    this.consume().destroy(new Error(resultSetClosedMessage))
+    this._stream.destroy(new Error(resultSetClosedMessage))
   }
 
   /**

--- a/packages/client-node/src/result_set.ts
+++ b/packages/client-node/src/result_set.ts
@@ -69,6 +69,12 @@ export class ResultSet<
   private readonly jsonHandling: JSONHandling
 
   constructor(
+    /**
+     * The stream of the response body.
+     *
+     * It is expected that the stream is passed directly from the response of the HTTP request
+     * and has not been consumed or altered yet.
+     */
     private _stream: Stream.Readable,
     private readonly format: Format,
     public readonly query_id: string,

--- a/packages/client-node/src/result_set.ts
+++ b/packages/client-node/src/result_set.ts
@@ -130,7 +130,7 @@ export class ResultSet<
     // Stream.pipeline will create a new empty stream
     // but without "readableEnded" flag set to true
     if (this._stream.readableEnded) {
-      throw Error(streamAlreadyConsumedMessage)
+      throw new Error(streamAlreadyConsumedMessage)
     }
 
     validateStreamFormat(this.format)

--- a/packages/client-node/src/result_set.ts
+++ b/packages/client-node/src/result_set.ts
@@ -67,7 +67,6 @@ export class ResultSet<
   private readonly exceptionTag: string | undefined = undefined
   private readonly log_error: (error: Error) => void
   private readonly jsonHandling: JSONHandling
-  private _consumed = false
 
   constructor(
     private _stream: Stream.Readable,
@@ -92,38 +91,23 @@ export class ResultSet<
     }
   }
 
-  /**
-   * Mark the result set as consumed and throw if it was already consumed.
-   * Uses a boolean flag instead of checking `readableEnded` to avoid a race
-   * condition where the stream's 'end' event fires between two separate
-   * `readableEnded` checks (e.g. when `json()` calls `stream()` internally
-   * for JSONEachRow). See: https://github.com/ClickHouse/clickhouse-js/issues/575
-   *
-   * We intentionally do NOT check `readableEnded` here. A stream can have
-   * `readableEnded=true` (the 'end' event fired) while its data is still
-   * buffered and available for reading. Checking readableEnded would falsely
-   * reject the first consumption call for fast/small responses.
-   */
-  private markAsConsumed(): void {
-    if (this._consumed) {
-      throw Error(streamAlreadyConsumedMessage)
-    }
-    this._consumed = true
-  }
-
   /** See {@link BaseResultSet.text}. */
   async text(): Promise<string> {
-    this.markAsConsumed()
+    if (this._stream.readableEnded) {
+      throw Error(streamAlreadyConsumedMessage)
+    }
     return (await getAsText(this._stream)).toString()
   }
 
   /** See {@link BaseResultSet.json}. */
   async json<T>(): Promise<ResultJSONType<T, Format>> {
+    if (this._stream.readableEnded) {
+      throw Error(streamAlreadyConsumedMessage)
+    }
     // JSONEachRow, etc.
     if (isStreamableJSONFamily(this.format as DataFormat)) {
-      this.markAsConsumed()
       const result: T[] = []
-      const stream = this._streamImpl<T>()
+      const stream = this.stream<T>()
       for await (const rows of stream) {
         for (const row of rows) {
           result.push(row.json() as T)
@@ -133,30 +117,23 @@ export class ResultSet<
     }
     // JSON, JSONObjectEachRow, etc.
     if (isNotStreamableJSONFamily(this.format as DataFormat)) {
-      this.markAsConsumed()
       const text = await getAsText(this._stream)
       return this.jsonHandling.parse(text)
     }
     // should not be called for CSV, etc.
-    // Do NOT mark as consumed here — the caller can still use text() instead.
     throw new Error(`Cannot decode ${this.format} as JSON`)
   }
 
   /** See {@link BaseResultSet.stream}. */
   stream<T>(): ResultStream<Format, StreamReadable<Row<T, Format>[]>> {
-    // Validate format before marking as consumed, so that if the format is
-    // invalid, the ResultSet can still be consumed via text() afterwards.
-    validateStreamFormat(this.format)
-    this.markAsConsumed()
-    return this._streamImpl<T>()
-  }
+    // If the underlying stream has already ended by calling `text` or `json`,
+    // Stream.pipeline will create a new empty stream
+    // but without "readableEnded" flag set to true
+    if (this._stream.readableEnded) {
+      throw Error(streamAlreadyConsumedMessage)
+    }
 
-  /**
-   * Internal stream implementation that skips the consumption check
-   * and format validation. Used by `json()` which has already called
-   * `markAsConsumed()` and validated the format via `isStreamableJSONFamily`.
-   */
-  private _streamImpl<T>(): ResultStream<Format, StreamReadable<Row<T, Format>[]>> {
+    validateStreamFormat(this.format)
 
     const incompleteChunks: Buffer[] = []
     const logError = this.log_error


### PR DESCRIPTION
Follow-up for:
* https://github.com/ClickHouse/clickhouse-js/pull/603