### PR TITLE
test(common): cover enum ClickHouse settings

### DIFF
--- a/packages/client-common/__tests__/integration/clickhouse_settings.test.ts
+++ b/packages/client-common/__tests__/integration/clickhouse_settings.test.ts
@@ -1,10 +1,56 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest'
-import type { ClickHouseClient, InsertParams } from '@clickhouse/client-common'
+import type {
+  ClickHouseClient,
+  ClickHouseSettings,
+  InsertParams,
+} from '@clickhouse/client-common'
 import { SettingsMap } from '@clickhouse/client-common'
 import { createSimpleTable } from '../fixtures/simple_table'
 import { createTestClient, guid } from '../utils'
 
-// TODO: cover at least all enum settings
+const enumSettings = [
+  ['date_time_input_format', 'best_effort'],
+  ['date_time_output_format', 'iso'],
+  ['default_table_engine', 'Memory'],
+  ['default_temporary_table_engine', 'Memory'],
+  ['dialect', 'clickhouse'],
+  ['distinct_overflow_mode', 'break'],
+  ['distributed_ddl_output_mode', 'none'],
+  ['distributed_product_mode', 'global'],
+  ['except_default_mode', 'ALL'],
+  ['format_capn_proto_enum_comparising_mode', 'by_names'],
+  ['format_custom_escaping_rule', 'Raw'],
+  ['format_regexp_escaping_rule', 'Raw'],
+  ['group_by_overflow_mode', 'any'],
+  ['intersect_default_mode', 'DISTINCT'],
+  ['interval_output_format', 'kusto'],
+  ['join_algorithm', 'hash'],
+  ['join_default_strictness', 'ANY'],
+  ['join_overflow_mode', 'break'],
+  ['load_balancing', 'round_robin'],
+  ['log_queries_min_type', 'EXCEPTION_WHILE_PROCESSING'],
+  ['mysql_datatypes_support_level', 'decimal'],
+  ['output_format_arrow_compression_method', 'none'],
+  ['output_format_msgpack_uuid_representation', 'str'],
+  ['output_format_orc_compression_method', 'none'],
+  ['output_format_parquet_compression_method', 'none'],
+  ['output_format_parquet_version', '2.6'],
+  ['parallel_replicas_custom_key_filter_type', 'default'],
+  ['read_overflow_mode', 'break'],
+  ['read_overflow_mode_leaf', 'break'],
+  ['result_overflow_mode', 'break'],
+  ['send_logs_level', 'fatal'],
+  ['set_overflow_mode', 'break'],
+  ['short_circuit_function_evaluation', 'enable'],
+  ['sort_overflow_mode', 'break'],
+  ['storage_file_read_method', 'read'],
+  ['timeout_overflow_mode', 'break'],
+  ['totals_mode', 'after_having_inclusive'],
+  ['transfer_overflow_mode', 'break'],
+  ['union_default_mode', 'ALL'],
+  ['wait_changes_become_visible_after_commit_mode', 'async'],
+] satisfies Array<[keyof ClickHouseSettings, string]>
+
 describe('ClickHouse settings', () => {
   let client: ClickHouseClient
   beforeEach(() => {
@@ -28,6 +74,24 @@ describe('ClickHouse settings', () => {
       .then((r) => r.text())
     expect(result).toEqual('0\n1\n2\n4\n5\n')
   })
+
+  it.each(enumSettings)(
+    'should work with enum setting %s',
+    async (name, value) => {
+      const clickhouse_settings: ClickHouseSettings = {
+        [name]: value,
+      }
+      const result = await client
+        .query({
+          query: `SELECT toString(getSetting('${name}')) AS value`,
+          format: 'JSONEachRow',
+          clickhouse_settings,
+        })
+        .then((r) => r.json<{ value: string }>())
+
+      expect(result).toEqual([{ value }])
+    },
+  )
 
   // covers both command and insert settings behavior
   // `insert_deduplication_token` will not work without


### PR DESCRIPTION
## Summary

Refs #54.

Adds integration-test coverage for the currently typed enum-style `ClickHouseSettings` entries. The test sends each enum setting through `clickhouse_settings` and verifies the server observes the value via `getSetting(...)`.

## Reproduction

`packages/client-common/__tests__/integration/clickhouse_settings.test.ts` already covered `SettingsMap` and `insert_deduplication_token`, but left a TODO to cover enum settings. There was no test that exercised the string-union settings listed in `packages/client-common/src/settings.ts`.

## Root cause

Enum-style settings are represented only as TypeScript union types, so they can drift without a runtime/integration test proving they are sent correctly to ClickHouse.

## Changes

- Replaced the enum-settings TODO with a table of all current enum-style setting names and representative valid values.
- Added a parameterized integration test that sends each setting and checks `toString(getSetting(...))`.

## Tests

- `PATH=/Users/liumin/.nvm/versions/node/v22.13.0/bin:$PATH npx prettier --check packages/client-common/__tests__/integration/clickhouse_settings.test.ts`
- `PATH=/Users/liumin/.nvm/versions/node/v22.13.0/bin:$PATH npm run typecheck --workspace @clickhouse/client-common`
- `git diff --check`

Attempted but could not complete locally:

- `PATH=/Users/liumin/.nvm/versions/node/v22.13.0/bin:$PATH npm run test:common:integration:node -- packages/client-common/__tests__/integration/clickhouse_settings.test.ts --run` failed because no local ClickHouse server is running (`ECONNREFUSED 127.0.0.1:8123`). The local environment also does not have `docker`, so I could not start the repository Docker Compose stack here.
- `PATH=/Users/liumin/.nvm/versions/node/v22.13.0/bin:$PATH npm run lint --workspace @clickhouse/client-common` failed on existing unrelated lint errors in `packages/client-common/src/parse/column_types.ts` (`@typescript-eslint/no-non-null-assertion`).

## Screenshots/Logs

Not applicable; test-only change.

## Checklist

- [x] Unit and integration tests covering the common scenarios were added
- [x] A human-readable description of the changes was provided to include in CHANGELOG
