### PR TITLE
Require CHANGELOG updates in-PR (contributor + review-agent guidance)

### DIFF
--- a/.github/instructions/review.instructions.md
+++ b/.github/instructions/review.instructions.md
@@ -17,6 +17,10 @@ In other cases when you've found a meaningful change to make, make it and push c
 
 When reviewing PRs to the `release` branch focus on flagging breaking changes and security issues in the broader context, as PRs to the `release` branch are normally bigger and include a cumulative change from a number of PRs.
 
+## CHANGELOG
+
+Every PR that adds a feature, fixes a bug, or changes observable behavior or the public API **must update `CHANGELOG.md` in the same PR**. If such a change does not touch `CHANGELOG.md`, flag it and ask the author to add an entry (a note in the PR description alone is not sufficient). Verify the entry follows the conventions in [`AGENTS.md`](../../AGENTS.md) ("API quality and stability"): placed under the top-most version heading (a new `# x.y.z` heading matching the unreleased `package.json` version when the latest heading is already released), grouped under a lowercase section heading (`## New features` / `## Improvements` / `## Bug fixes`), and ending with a `([#<n>])` PR reference link. Pure refactors, test-only changes, docs, and CI/tooling changes do not require a CHANGELOG entry.
+
 ## Breaking changes
 
 Always flag major breaking changes to the public API (removed/renamed exports, changed function signatures, changed default behavior, removed configuration options, etc.) when they are not accompanied by a clear explanation in the PR description or PR discussion/code comments justifying why the break is necessary. This is important because LLMs generating code against newer client versions rely heavily on training data from older versions; undocumented breaking changes degrade their effectiveness and produce broken code for users. When such a change lacks justification, request that the author either add a clear rationale (and, where possible, a migration note) or restore backwards compatibility (e.g., via a deprecation path).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -113,6 +113,11 @@ For every pull request review, make sure to provide an evaluation of the followi
 
 1. When reviewing code changes, it is important to consider the impact on the API quality and stability. For example, if the code changes involve modifying the library's public API surface (such as exported functions, classes, or types) or adding new public APIs, it is important to ensure that the changes are well-documented and do not break existing functionality for users of the library.
 
-2. When introducing new features or making changes to the API, make sure the PR description includes a concise, human-readable CHANGELOG entry (followed by an example usage if applicable) so it can be folded into `CHANGELOG.md` at release time. This matches the PR template checklist item ("A human-readable description of the changes was provided to include in CHANGELOG").
+2. When introducing new features, fixing bugs, or making any change to observable behavior or the public API, you **must update [`CHANGELOG.md`](CHANGELOG.md) in the same PR** — do not defer it to "release time" or leave it only in the PR description. This satisfies the PR template checklist item ("A human-readable description of the changes was provided to include in CHANGELOG"). Follow the existing format exactly:
+   - Entries go under the **top-most version heading**. If the most recent `# x.y.z` heading corresponds to an **already-released** version (check `git tag`), open a **new** top-level `# x.y.z` heading that matches the unreleased version in `package.json` (e.g. the `version` field of [`packages/client-common/package.json`](packages/client-common/package.json)); otherwise append to the existing top heading.
+   - Group entries under lowercase section headings, reusing the ones already in the file: `## New features`, `## Improvements`, `## Bug fixes` (and `## Migration Notes` / `## Breaking changes` when relevant).
+   - Write a concise, human-readable entry, add an example usage when it helps, and end it with a PR reference link, e.g. `([#825])` plus a matching `[#825]: https://github.com/ClickHouse/clickhouse-js/pull/<n>` reference at the bottom of the section.
+   - When a change is Node.js- or Web-only, say so explicitly in the entry (e.g. "(Node.js only)").
+   - Run `npx prettier --write CHANGELOG.md` before committing.
 
 3. Additionally, make sure that the official documentation is in sync with the changes.


### PR DESCRIPTION
## Summary

Makes updating `CHANGELOG.md` a same-PR requirement rather than something deferred to release time, and teaches the Copilot review agent to enforce it.

- **`AGENTS.md`** (*API quality and stability*): the CHANGELOG step is now mandatory in the same PR, with explicit formatting rules — top-most version heading (or a new `# x.y.z` heading matching the unreleased `package.json` version when the latest is already tagged), lowercase section headings (`## New features` / `## Improvements` / `## Bug fixes`), a `([#n])` PR reference link, platform scoping (Node.js-/Web-only), and a prettier pass.
- **`.github/instructions/review.instructions.md`**: instructs the review agent to flag any feature/bugfix/behavior PR that doesn't touch `CHANGELOG.md` (a PR-description note is not sufficient) and to verify the entry follows the conventions. Pure refactors/tests/docs/CI are exempt.

Split out of #825, where this guidance was first drafted.

## Checklist

- [ ] Unit and integration tests covering the common scenarios were added
- [x] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials

🤖 Generated with [Claude Code](https://claude.com/claude-code)