### PR TITLE
Skip 02346_text_index_byte_size_reporting on latest ClickHouse

### DIFF
--- a/tests/clickhouse-test-runner/upstream-allowlist.txt
+++ b/tests/clickhouse-test-runner/upstream-allowlist.txt
@@ -1482,7 +1482,7 @@
 02346_text_index_bug84805
 02346_text_index_bug87887
 02346_text_index_bug93432
-02346_text_index_byte_size_reporting
+# 02346_text_index_byte_size_reporting: TODO: failing against latest ClickHouse stable; uses setting 'text_index_dictionary_block_size' not yet in the latest Docker release (passes on head).
 02346_text_index_collapsingmergetree
 02346_text_index_default_granularity
 02346_text_index_detach_attach


### PR DESCRIPTION
## What

Comments `02346_text_index_byte_size_reporting` out of `tests/clickhouse-test-runner/upstream-allowlist.txt`.

## Why

This upstream stateless test sets the MergeTree setting `text_index_dictionary_block_size`, which does **not** exist in the latest released ClickHouse Docker image. As a result the test fails deterministically on the `upstream-sql-tests (latest, *)` shard:

```
[165/312] 02346_text_index_byte_size_reporting: [ FAIL ]
ClickHouseError: Unknown setting 'text_index_dictionary_block_size': for storage MergeTree
→ 311 passed, 1 error
```

It passes on the `head` shard (the setting exists on ClickHouse master), so this is a server version-skew, not a client regression. This surfaced on Dependabot PR #850 but is unrelated to that dependency bump — it affects `main`/`latest` too.

The fix follows the existing allowlist convention for tests that depend on server features not yet in the latest stable release (e.g. `00516_is_inf_nan`). It can be re-enabled once `text_index_dictionary_block_size` ships in a stable ClickHouse release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)