### PR TITLE
Smoke-test the packed Node.js client tarball before publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,6 +13,11 @@ name: "publish"
 # The automatic head publish runs one per-package job for every package (each
 # computes its own `<base>-head.<sha>.<attempt>` version from its package.json).
 #
+# Before each Node.js client publish, a smoke test packs the freshly built
+# package into a tarball, installs that tarball into a throwaway app, and runs
+# ESM + CJS checks against it (.scripts/smoke_test_pack.sh). This catches
+# packaging problems before anything reaches npm.
+#
 # After a successful publish, the `e2e` job waits for the freshly published
 # version to become available on the npm registry, installs that exact
 # version into a tiny downstream project, and verifies it is usable. It only
@@ -93,6 +98,9 @@ jobs:
 
       - name: Build the package
         run: npm --workspace @clickhouse/client run build
+
+      - name: Smoke test the packed tarball
+        run: .scripts/smoke_test_pack.sh @clickhouse/client
 
       - name: Publish @clickhouse/client with head tag
         run: |
@@ -206,6 +214,9 @@ jobs:
 
       - name: Build the package
         run: npm --workspace @clickhouse/client run build
+
+      - name: Smoke test the packed tarball
+        run: .scripts/smoke_test_pack.sh @clickhouse/client
 
       - name: Publish @clickhouse/client to the latest tag (implicit)
         run: |

--- a/.scripts/smoke_test_pack.sh
+++ b/.scripts/smoke_test_pack.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+#
+# Pre-publish smoke test.
+#
+# Packs an already-built workspace into a tarball, installs that tarball into a
+# throwaway app (install-from-artifact only, exactly as a downstream consumer
+# would), and runs ESM + CJS checks against it. This catches packaging problems
+# - missing files, broken exports, unexpected transitive deps - before the
+# package is published to npm, rather than after.
+#
+# Usage: .scripts/smoke_test_pack.sh [workspace]
+#   workspace defaults to @clickhouse/client.
+#
+# Run from the repository root, after `npm run build` (or a per-workspace build).
+set -euo pipefail
+
+WORKSPACE="${1:-@clickhouse/client}"
+REPO="$(pwd)"
+SMOKE_DIR="$REPO/tests/e2e/smoke"
+
+APP="$(mktemp -d)/smoke-app"
+mkdir -p "$APP"
+# Clean up the throwaway app even if a check fails.
+trap 'rm -rf "$(dirname "$APP")"' EXIT
+
+TARBALL="$(npm pack -w "$WORKSPACE" --pack-destination "$APP" --json \
+  | node -e "console.log(JSON.parse(require('fs').readFileSync(0))[0].filename)")"
+echo "Packed $WORKSPACE -> $TARBALL"
+
+cp "$SMOKE_DIR/check.mjs" "$SMOKE_DIR/check.cjs" "$APP/"
+cd "$APP"
+npm init -y >/dev/null
+npm install "./$TARBALL"
+
+echo "--- installed @clickhouse packages ---"
+ls node_modules/@clickhouse/
+
+echo "--- ESM check ---"
+node check.mjs
+echo "--- CJS check ---"
+node check.cjs
+
+cd "$REPO"
+echo "Smoke test passed for $WORKSPACE."

--- a/tests/e2e/smoke/check.cjs
+++ b/tests/e2e/smoke/check.cjs
@@ -2,18 +2,24 @@
 //
 // Same intent as check.mjs, but resolves the package via `require()` to cover
 // the CJS entry point of the published artifact.
-const assert = require('node:assert')
-const { parseColumnType, SettingsMap, ClickHouseError } = require('@clickhouse/client')
+const assert = require("node:assert");
+const {
+  parseColumnType,
+  SettingsMap,
+  ClickHouseError,
+} = require("@clickhouse/client");
 
-const t = parseColumnType('Array(String)')
-console.log('parseColumnType("Array(String)") =>', JSON.stringify(t))
-assert.equal(t.type, 'Array')
-assert.equal(t.value.columnType, 'String')
+const t = parseColumnType("Array(String)");
+console.log('parseColumnType("Array(String)") =>', JSON.stringify(t));
+assert.equal(t.type, "Array");
+assert.equal(t.value.columnType, "String");
 
-const sm = SettingsMap.from({ max_block_size: '1000' })
-console.log('SettingsMap.toString() =>', sm.toString())
-assert.equal(typeof sm.toString(), 'string')
+const sm = SettingsMap.from({ max_block_size: "1000" });
+console.log("SettingsMap.toString() =>", sm.toString());
+assert.equal(typeof sm.toString(), "string");
 
-assert.equal(typeof ClickHouseError, 'function')
+assert.equal(typeof ClickHouseError, "function");
 
-console.log('OK (CJS): all common-origin imports resolved and executed from the installed package')
+console.log(
+  "OK (CJS): all common-origin imports resolved and executed from the installed package",
+);

--- a/tests/e2e/smoke/check.cjs
+++ b/tests/e2e/smoke/check.cjs
@@ -1,0 +1,19 @@
+// Pre-publish smoke test (CommonJS).
+//
+// Same intent as check.mjs, but resolves the package via `require()` to cover
+// the CJS entry point of the published artifact.
+const assert = require('node:assert')
+const { parseColumnType, SettingsMap, ClickHouseError } = require('@clickhouse/client')
+
+const t = parseColumnType('Array(String)')
+console.log('parseColumnType("Array(String)") =>', JSON.stringify(t))
+assert.equal(t.type, 'Array')
+assert.equal(t.value.columnType, 'String')
+
+const sm = SettingsMap.from({ max_block_size: '1000' })
+console.log('SettingsMap.toString() =>', sm.toString())
+assert.equal(typeof sm.toString(), 'string')
+
+assert.equal(typeof ClickHouseError, 'function')
+
+console.log('OK (CJS): all common-origin imports resolved and executed from the installed package')

--- a/tests/e2e/smoke/check.mjs
+++ b/tests/e2e/smoke/check.mjs
@@ -1,0 +1,22 @@
+// Pre-publish smoke test (ESM).
+//
+// Imports symbols that originate in the (now bundled) `common` sources and are
+// re-exported from `@clickhouse/client` via `./common/index`. Exercising them
+// from a tarball install proves the bundled common code is compiled into the
+// published artifact and usable by consumers - without `@clickhouse/client-common`
+// as a runtime dependency.
+import { parseColumnType, SettingsMap, ClickHouseError } from '@clickhouse/client'
+import assert from 'node:assert'
+
+const t = parseColumnType('Nullable(UInt64)')
+console.log('parseColumnType("Nullable(UInt64)") =>', JSON.stringify(t))
+assert.equal(t.type, 'Nullable')
+assert.equal(t.value.columnType, 'UInt64')
+
+const sm = SettingsMap.from({ max_block_size: '1000' })
+console.log('SettingsMap.toString() =>', sm.toString())
+assert.equal(typeof sm.toString(), 'string')
+
+assert.equal(typeof ClickHouseError, 'function')
+
+console.log('OK (ESM): all common-origin imports resolved and executed from the installed package')

--- a/tests/e2e/smoke/check.mjs
+++ b/tests/e2e/smoke/check.mjs
@@ -5,18 +5,24 @@
 // from a tarball install proves the bundled common code is compiled into the
 // published artifact and usable by consumers - without `@clickhouse/client-common`
 // as a runtime dependency.
-import { parseColumnType, SettingsMap, ClickHouseError } from '@clickhouse/client'
-import assert from 'node:assert'
+import {
+  parseColumnType,
+  SettingsMap,
+  ClickHouseError,
+} from "@clickhouse/client";
+import assert from "node:assert";
 
-const t = parseColumnType('Nullable(UInt64)')
-console.log('parseColumnType("Nullable(UInt64)") =>', JSON.stringify(t))
-assert.equal(t.type, 'Nullable')
-assert.equal(t.value.columnType, 'UInt64')
+const t = parseColumnType("Nullable(UInt64)");
+console.log('parseColumnType("Nullable(UInt64)") =>', JSON.stringify(t));
+assert.equal(t.type, "Nullable");
+assert.equal(t.value.columnType, "UInt64");
 
-const sm = SettingsMap.from({ max_block_size: '1000' })
-console.log('SettingsMap.toString() =>', sm.toString())
-assert.equal(typeof sm.toString(), 'string')
+const sm = SettingsMap.from({ max_block_size: "1000" });
+console.log("SettingsMap.toString() =>", sm.toString());
+assert.equal(typeof sm.toString(), "string");
 
-assert.equal(typeof ClickHouseError, 'function')
+assert.equal(typeof ClickHouseError, "function");
 
-console.log('OK (ESM): all common-origin imports resolved and executed from the installed package')
+console.log(
+  "OK (ESM): all common-origin imports resolved and executed from the installed package",
+);


### PR DESCRIPTION
## Summary

Adds a **pre-publish smoke test** to the `publish` workflow: before the Node.js client is published, the freshly built `@clickhouse/client` is packed into a tarball, installed into a throwaway app, and exercised via ESM + CJS checks. This catches packaging problems — missing files, broken exports, unexpected transitive deps — *before* anything reaches npm, complementing the existing post-publish `e2e` job (which installs from the registry after publishing).

Stacked on #845 — the per-package publish jobs and the bundled-`common` change it verifies live there.

## Changes

- **`.scripts/smoke_test_pack.sh`** — packs an already-built workspace (`npm pack --pack-destination`), installs the tarball into a temp app (install-from-artifact only, as a downstream consumer would), and runs the ESM + CJS checks. Cleans up the temp app on exit. Defaults to `@clickhouse/client`.
- **`tests/e2e/smoke/check.mjs` / `check.cjs`** — import symbols that originate in the bundled `common` sources (`parseColumnType`, `SettingsMap`, `ClickHouseError`, re-exported via `./common/index`) and assert they resolve and execute. This proves the shared code is compiled into the published artifact and usable with **no `@clickhouse/client-common` runtime dependency**.
- **`.github/workflows/publish.yml`** — a `Smoke test the packed tarball` step runs after build and before publish in both Node.js client jobs (`head_client` and `publish_client`), so a failure blocks the publish.

## Verification

Ran the script locally exactly as CI does (`npm --workspace @clickhouse/client run build` then `.scripts/smoke_test_pack.sh`):

```console
Packed @clickhouse/client -> clickhouse-client-1.22.0.tgz
--- installed @clickhouse packages ---
client
--- ESM check ---
OK (ESM): all common-origin imports resolved and executed from the installed package
--- CJS check ---
OK (CJS): all common-origin imports resolved and executed from the installed package
Smoke test passed for @clickhouse/client.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)