### PR TITLE
ci: support the release branch for tests and rowbinary publish

### DIFF
--- a/.github/workflows/publish-skill-rowbinary-parser.yml
+++ b/.github/workflows/publish-skill-rowbinary-parser.yml
@@ -4,12 +4,15 @@ name: "publish: rowbinary parser"
 # package (the RowBinary parser skill). It is NOT part of the npm workspace
 # lockstep release driven by publish.yml — it carries its own version in
 # skills/clickhouse-js-node-rowbinary-parser/package.json and ships on its own
-# cadence. Triggered manually; the `publish` job gates on typecheck/test/build,
-# publishes the version currently in package.json with the "latest" tag using
-# npm OIDC authentication and provenance, then pushes a matching git tag. The
-# `e2e` job waits for the freshly published version to appear on the registry
-# and verifies it installs and imports in a throwaway downstream project across
-# the supported Node versions.
+# cadence. Triggered manually, and — like publish.yml — must be dispatched from
+# the `release` branch: the npm-publish environment is protected so only that
+# branch may deploy (the repo's human-in-the-loop release gate). Dispatches from
+# any other ref are skipped by the job-level `if` guard below. The `publish` job
+# gates on typecheck/test/build, publishes the version currently in package.json
+# with the "latest" tag using npm OIDC authentication and provenance, then pushes
+# a matching git tag. The `e2e` job waits for the freshly published version to
+# appear on the registry and verifies it installs and imports in a throwaway
+# downstream project across the supported Node versions.
 
 permissions:
   contents: read
@@ -24,6 +27,9 @@ on:
 
 jobs:
   publish:
+    # The npm-publish environment only permits the release branch to deploy;
+    # skip cleanly on any other ref instead of failing the protection check.
+    if: github.ref == 'refs/heads/release'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     environment: npm-publish

--- a/.github/workflows/tests-bun.yml
+++ b/.github/workflows/tests-bun.yml
@@ -6,6 +6,7 @@ on:
   push:
     branches:
       - main
+      - release
     paths:
       - "packages/**"
       - "tests/**"

--- a/.github/workflows/tests-node.yml
+++ b/.github/workflows/tests-node.yml
@@ -6,6 +6,7 @@ on:
   push:
     branches:
       - main
+      - release
     paths:
       - "packages/**"
       - "tests/**"

--- a/.github/workflows/tests-oss-dependents.yml
+++ b/.github/workflows/tests-oss-dependents.yml
@@ -6,6 +6,7 @@ on:
   push:
     branches:
       - main
+      - release
     paths:
       - "packages/**"
       - "tests/**"

--- a/.github/workflows/tests-web.yml
+++ b/.github/workflows/tests-web.yml
@@ -6,6 +6,7 @@ on:
   push:
     branches:
       - main
+      - release
     paths:
       - "packages/**"
       - "tests/**"


### PR DESCRIPTION
Follow-up to #870.

## Why

Dispatching the rowbinary publish workflow from `main` is rejected by GitHub:

> Branch "main" is not allowed to deploy to npm-publish due to environment protection rules.

The `npm-publish` environment is branch-protected to the `release` branch — the repo's human-in-the-loop release gate (same model as `publish.yml`, whose jobs are guarded by `if: github.ref == 'refs/heads/release'`). The standalone rowbinary publish workflow lacked that guard, and the main test suites weren't validating the `release` branch on push.

## Changes

- **`publish-skill-rowbinary-parser.yml`**: guard the `publish` job with `if: github.ref == 'refs/heads/release'` so it skips cleanly on other refs instead of failing the environment protection check, and document that it must be dispatched from `release`.
- **`tests-node` / `tests-web` / `tests-bun` / `tests-oss-dependents`**: add `release` to the push-trigger branches so the release branch is validated before/as it publishes (`examples.yml` already had it).

## Release flow (unchanged, now consistent)

1. Land changes on `main`.
2. Promote to `release` → test suites run on the release branch.
3. Dispatch `publish: rowbinary parser` from `release` → publishes with OIDC/provenance and tags `rowbinary-v<version>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)