### PR TITLE
Address PR #876 review comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,14 @@
 # 1.23.0
 
+## Migration Notes
+
+- The `@clickhouse/client-common` package is deprecated. `@clickhouse/client` (Node.js) and `@clickhouse/client-web` (Web) no longer depend on it; the shared code is now bundled into each client package. Everything previously importable from `@clickhouse/client-common` should be imported from `@clickhouse/client` or `@clickhouse/client-web` instead. The `@clickhouse/client-common` package itself will no longer receive updates. ([#845])
+
 ## New features
 
 - (Node.js) Added a RowBinary reader library and agent skill under [`skills/clickhouse-js-node-rowbinary-parser`](./skills/clickhouse-js-node-rowbinary-parser). It ships type-specific, monomorphizable building blocks for decoding `RowBinary` / `RowBinaryWithNames` / `RowBinaryWithNamesAndTypes` streams (full-buffer and chunked), plus a skill that guides an agent to generate bespoke high-performance parsers from a query's column types. The skill is bundled into `@clickhouse/client` (registered in `agents.skills`) and is also published independently as the [`@clickhouse/rowbinary`](https://www.npmjs.com/package/@clickhouse/rowbinary) package. A matching RowBinary writer is planned. ([#864])
 
 # 1.22.0
-
-## Migration Notes
-
-- The `@clickhouse/client-common` package is deprecated. `@clickhouse/client` (Node.js) and `@clickhouse/client-web` (Web) no longer depend on it; the shared code is now bundled into each client package. Everything previously importable from `@clickhouse/client-common` should be imported from `@clickhouse/client` or `@clickhouse/client-web` instead. The `@clickhouse/client-common` package itself will no longer receive updates. ([#845])
 
 ## New features
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -3,7 +3,7 @@
 Tools required (for verifying a published build and promoting npm tags locally):
 
 - Node.js >= `20.x`
-- NPM >= `11.x`
+- npm >= `11.x` — newer than the npm bundled with Node.js `20.x`/`22.x` (`10.x`). Either upgrade npm in place (`npm install -g npm@latest`) or use Node.js `24.x`, which already ships npm `11.x`.
 
 Packages are versioned and released independently. Release one package at a time; to release several, repeat the steps below for each. Versions are bumped through the GitHub Actions workflows — there is no local version-bump script.
 

--- a/tests/e2e/smoke/check.cjs
+++ b/tests/e2e/smoke/check.cjs
@@ -11,14 +11,14 @@ const {
 
 const t = parseColumnType("Array(String)");
 console.log('parseColumnType("Array(String)") =>', JSON.stringify(t));
-assert.equal(t.type, "Array");
-assert.equal(t.value.columnType, "String");
+assert.strictEqual(t.type, "Array");
+assert.strictEqual(t.value.columnType, "String");
 
 const sm = SettingsMap.from({ max_block_size: "1000" });
 console.log("SettingsMap.toString() =>", sm.toString());
-assert.equal(typeof sm.toString(), "string");
+assert.strictEqual(typeof sm.toString(), "string");
 
-assert.equal(typeof ClickHouseError, "function");
+assert.strictEqual(typeof ClickHouseError, "function");
 
 console.log(
   "OK (CJS): all common-origin imports resolved and executed from the installed package",

--- a/tests/e2e/smoke/check.mjs
+++ b/tests/e2e/smoke/check.mjs
@@ -14,14 +14,14 @@ import assert from "node:assert";
 
 const t = parseColumnType("Nullable(UInt64)");
 console.log('parseColumnType("Nullable(UInt64)") =>', JSON.stringify(t));
-assert.equal(t.type, "Nullable");
-assert.equal(t.value.columnType, "UInt64");
+assert.strictEqual(t.type, "Nullable");
+assert.strictEqual(t.value.columnType, "UInt64");
 
 const sm = SettingsMap.from({ max_block_size: "1000" });
 console.log("SettingsMap.toString() =>", sm.toString());
-assert.equal(typeof sm.toString(), "string");
+assert.strictEqual(typeof sm.toString(), "string");
 
-assert.equal(typeof ClickHouseError, "function");
+assert.strictEqual(typeof ClickHouseError, "function");
 
 console.log(
   "OK (ESM): all common-origin imports resolved and executed from the installed package",


### PR DESCRIPTION
## Summary

Addresses the Copilot review comments on #876.

- **CHANGELOG.md** — moved the `@clickhouse/client-common` deprecation *Migration Notes* from the `1.22.0` heading to the unreleased `1.23.0` heading, since that observable change (node/web no longer depend on client-common) ships in this release.
- **RELEASING.md** — clarified the npm `11.x` requirement: it's newer than the npm bundled with Node.js `20.x`/`22.x` (`10.x`); either upgrade npm in place or use Node.js `24.x` (which ships npm `11.x`).
- **tests/e2e/smoke/check.mjs** / **check.cjs** — use `assert.strictEqual` instead of loose `assert.equal`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)