### PR TITLE
chore: add 7-day Dependabot cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,8 @@ updates:
     schedule:
       interval: "weekly"
       day: "monday"
+    cooldown:
+      default-days: 7
     groups:
       workflows:
         dependency-type: "development"
@@ -14,6 +16,10 @@ updates:
     schedule:
       interval: "weekly"
       day: "monday"
+    cooldown:
+      default-days: 7
+      exclude:
+        - "@clickhouse/*"
     groups:
       dev-dependencies:
         dependency-type: "development"


### PR DESCRIPTION
7-day Dependabot cooldown for npm and github-actions. 

key is `cooldown.default-days`, not `minimum-release-age` (that's Renovate's), Dependabot silently ignores unknown keys: https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#cooldown--

