### PR TITLE
ci: add 7-day lockfile age audit for package-lock.json

### DIFF
--- a/.github/workflows/lockfile-age-audit.yml
+++ b/.github/workflows/lockfile-age-audit.yml
@@ -1,0 +1,68 @@
+name: Lockfile age audit
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: lockfile-age-audit-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      # Step-level skip (not job-level) so the job still completes with status "success"
+      # when the label is set — required for branch protection to be satisfied.
+      - name: Honor lockfile-age-skip label
+        id: skip
+        env:
+          SKIP: ${{ contains(github.event.pull_request.labels.*.name, 'lockfile-age-skip') }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ "$SKIP" == "true" ]]; then
+            echo "lockfile-age-skip label present — audit will be bypassed."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        if: steps.skip.outputs.skip == 'false'
+        with:
+          fetch-depth: 0
+      - name: Ensure base ref is fetched
+        if: steps.skip.outputs.skip == 'false'
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          git fetch --no-tags --quiet origin "$BASE_REF":"refs/remotes/origin/$BASE_REF"
+      - name: Detect package-lock.json change
+        id: lockfile
+        if: steps.skip.outputs.skip == 'false'
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          changed_files=$(git diff --name-only "origin/${BASE_REF}...HEAD")
+          if echo "$changed_files" | grep -qx 'package-lock.json'; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          fi
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        if: steps.skip.outputs.skip == 'false' && steps.lockfile.outputs.changed == 'true'
+        with:
+          node-version: "22"
+      - name: Audit new package-lock.json entries against 7-day age gate
+        if: steps.skip.outputs.skip == 'false' && steps.lockfile.outputs.changed == 'true'
+        env:
+          MIN_AGE_DAYS: "7"
+          GITHUB_BASE_REF: ${{ github.base_ref }}
+        run: node scripts/ci/lockfile-age-audit.mjs

--- a/scripts/ci/lockfile-age-audit.mjs
+++ b/scripts/ci/lockfile-age-audit.mjs
@@ -130,7 +130,9 @@ const violations = []
 const errors = []
 
 async function checkOne({ name, version }) {
-  const url = `https://registry.npmjs.org/${name.replace('/', '%2F')}`
+  // Scoped names contain '/' which must be percent-encoded for the registry URL.
+  // encodeURIComponent handles all unsafe chars (replace('/', ...) only hits the first).
+  const url = `https://registry.npmjs.org/${encodeURIComponent(name)}`
   let res
   try {
     res = await fetch(url, { headers: { Accept: 'application/vnd.npm.install-v1+json' } })

--- a/scripts/ci/lockfile-age-audit.mjs
+++ b/scripts/ci/lockfile-age-audit.mjs
@@ -1,0 +1,200 @@
+#!/usr/bin/env node
+// Fails if the PR introduces package-lock.json entries published less than MIN_AGE_DAYS ago.
+// True new entries only — compares base vs head lockfile resolutions, not just diff `+` lines,
+// so lockfile reorders don't trigger false positives.
+// Skips first-party @clickhouse/* packages (no upstream-compromise risk).
+// Fails closed on registry errors (skip via the 'lockfile-age-skip' PR label).
+import { execSync } from 'node:child_process'
+import { readFileSync } from 'node:fs'
+
+const MIN_AGE_DAYS = parseInt(process.env.MIN_AGE_DAYS ?? '7', 10)
+const BASE_REF = process.env.GITHUB_BASE_REF || 'main'
+const cutoffMs = Date.now() - MIN_AGE_DAYS * 86400_000
+
+// First-party scopes — npm has no native equivalent to yarn's npmPreapprovedPackages,
+// so hardcoded here. Mirrors the Dependabot cooldown.exclude list.
+const PREAPPROVED_SCOPES = ['@clickhouse/']
+
+const REGISTRY_HOSTS = ['registry.npmjs.org', 'registry.npmmirror.com']
+
+function isRegistryEntry(resolved) {
+  if (!resolved || typeof resolved !== 'string') return false
+  try {
+    const u = new URL(resolved)
+    return REGISTRY_HOSTS.includes(u.host)
+  } catch {
+    return false
+  }
+}
+
+function isPreapproved(name) {
+  return PREAPPROVED_SCOPES.some((scope) => name.startsWith(scope))
+}
+
+// node_modules/foo                 -> foo
+// node_modules/@scope/bar          -> @scope/bar
+// node_modules/foo/node_modules/baz -> baz
+// node_modules/foo/node_modules/@scope/baz -> @scope/baz
+function packageNameFromPath(path) {
+  const idx = path.lastIndexOf('node_modules/')
+  if (idx === -1) return null
+  return path.slice(idx + 'node_modules/'.length)
+}
+
+function extractNpmResolutions(text) {
+  const out = new Map()
+  let parsed
+  try {
+    parsed = JSON.parse(text)
+  } catch (err) {
+    throw new Error(`Invalid JSON in lockfile: ${err.message}`)
+  }
+  const version = parsed.lockfileVersion
+  if (version !== 2 && version !== 3) {
+    throw new Error(
+      `Unsupported lockfileVersion ${version}. This audit handles package-lock.json v2/v3 (npm 7+).`,
+    )
+  }
+  const packages = parsed.packages
+  if (!packages || typeof packages !== 'object') return out
+  for (const [path, entry] of Object.entries(packages)) {
+    if (path === '') continue // root project
+    if (!entry || typeof entry !== 'object') continue
+    if (entry.link === true) continue // workspace symlinks
+    if (!entry.version) continue
+    if (!isRegistryEntry(entry.resolved)) continue
+    const name = packageNameFromPath(path)
+    if (!name) continue
+    // Key by name@version so multiple paths resolving to the same registry entry collapse.
+    const key = `${name}@${entry.version}`
+    out.set(key, { name, version: entry.version })
+  }
+  return out
+}
+
+// Use the merge-base, not the branch tip — what the PR *actually introduced*
+// is what's in head but not in the common ancestor with main. Comparing
+// against the branch tip would flag stale pins as "new" when they pre-date
+// the PR.
+let mergeBase
+try {
+  mergeBase = execSync(`git merge-base "origin/${BASE_REF}" HEAD`, {
+    encoding: 'utf8',
+  }).trim()
+} catch (err) {
+  console.error(`Could not find merge-base of HEAD and origin/${BASE_REF}: ${err.message}`)
+  process.exit(2)
+}
+
+let baseLockfile
+try {
+  baseLockfile = execSync(`git show "${mergeBase}:package-lock.json"`, {
+    encoding: 'utf8',
+    maxBuffer: 256 * 1024 * 1024,
+  })
+} catch (err) {
+  console.error(
+    `Could not read package-lock.json at merge-base ${mergeBase.slice(0, 10)}: ${err.message}`,
+  )
+  console.error(
+    `If package-lock.json is being introduced for the first time, use the 'lockfile-age-skip' label.`,
+  )
+  process.exit(2)
+}
+const headLockfile = readFileSync('package-lock.json', 'utf8')
+
+let baseResolutions, headResolutions
+try {
+  baseResolutions = extractNpmResolutions(baseLockfile)
+  headResolutions = extractNpmResolutions(headLockfile)
+} catch (err) {
+  console.error(err.message)
+  process.exit(2)
+}
+
+const added = new Map()
+for (const [key, value] of headResolutions) {
+  if (baseResolutions.has(key)) continue
+  if (isPreapproved(value.name)) continue
+  added.set(key, value)
+}
+
+if (added.size === 0) {
+  console.log('No new npm resolutions to audit.')
+  process.exit(0)
+}
+
+console.log(`Auditing ${added.size} new lockfile entries against ${MIN_AGE_DAYS}-day age gate.`)
+
+const violations = []
+const errors = []
+
+async function checkOne({ name, version }) {
+  const url = `https://registry.npmjs.org/${name.replace('/', '%2F')}`
+  let res
+  try {
+    res = await fetch(url, { headers: { Accept: 'application/vnd.npm.install-v1+json' } })
+  } catch (err) {
+    errors.push(`${name}: fetch failed (${err.message})`)
+    return
+  }
+  if (!res.ok) {
+    errors.push(`${name}: registry returned ${res.status}`)
+    return
+  }
+  let data
+  try {
+    data = await res.json()
+  } catch {
+    errors.push(`${name}: invalid JSON from registry`)
+    return
+  }
+  const publishedAt = data.time?.[version]
+  if (!publishedAt) {
+    errors.push(`${name}@${version}: missing publish time in registry response`)
+    return
+  }
+  const publishedMs = new Date(publishedAt).getTime()
+  if (publishedMs > cutoffMs) {
+    const ageDays = Math.floor((Date.now() - publishedMs) / 86400_000)
+    const mergeAfter = new Date(publishedMs + MIN_AGE_DAYS * 86400_000).toISOString()
+    violations.push({ name, version, publishedAt, ageDays, mergeAfter })
+  }
+}
+
+const queue = [...added.values()]
+const CONCURRENCY = 8
+async function worker() {
+  while (queue.length) {
+    const next = queue.shift()
+    if (next) await checkOne(next)
+  }
+}
+await Promise.all(Array.from({ length: CONCURRENCY }, worker))
+
+let failed = false
+
+if (errors.length > 0) {
+  console.error(`\n✗ ${errors.length} registry lookup error(s) — failing closed:`)
+  for (const e of errors) console.error(`  - ${e}`)
+  failed = true
+}
+
+if (violations.length > 0) {
+  console.error(`\n✗ ${violations.length} entries younger than ${MIN_AGE_DAYS} days:`)
+  for (const v of violations) {
+    console.error(`  ${v.name}@${v.version}`)
+    console.error(`    published: ${v.publishedAt} (${v.ageDays} days ago)`)
+    console.error(`    mergeable after: ${v.mergeAfter}`)
+  }
+  const latestMergeAfter = violations.map((v) => v.mergeAfter).sort().at(-1)
+  console.error(`\nEarliest this PR can merge: ${latestMergeAfter}`)
+  failed = true
+}
+
+if (failed) {
+  console.error(`\nTo bypass for an urgent security fix, add the 'lockfile-age-skip' label to the PR.`)
+  process.exit(1)
+}
+
+console.log(`✓ All ${added.size} new entries ≥ ${MIN_AGE_DAYS} days old.`)

--- a/scripts/ci/lockfile-age-audit.mjs
+++ b/scripts/ci/lockfile-age-audit.mjs
@@ -7,7 +7,13 @@
 import { execSync } from 'node:child_process'
 import { readFileSync } from 'node:fs'
 
-const MIN_AGE_DAYS = parseInt(process.env.MIN_AGE_DAYS ?? '7', 10)
+const MIN_AGE_DAYS = Number.parseInt(process.env.MIN_AGE_DAYS ?? '7', 10)
+if (!Number.isFinite(MIN_AGE_DAYS) || MIN_AGE_DAYS <= 0) {
+  console.error(
+    `MIN_AGE_DAYS must be a positive integer (got: ${process.env.MIN_AGE_DAYS ?? '7'})`,
+  )
+  process.exit(2)
+}
 const BASE_REF = process.env.GITHUB_BASE_REF || 'main'
 const cutoffMs = Date.now() - MIN_AGE_DAYS * 86400_000
 


### PR DESCRIPTION
fails PRs that add `package-lock.json` entries published less than 7 days ago. complements the Dependabot cooldown by catching anything that bypasses it (manual edits, `--package-lock-only`, escape flags), audits the lockfile diff so it isn't tool-specific.

set-diff against `git merge-base origin/main HEAD`, not `+` lines, so lockfile reorders don't false-positive. existing lockfile grandfathered. ~1 registry request per added package, concurrency 8. `@clickhouse/*` excluded.

escape hatch is the `lockfile-age-skip` label, for legit CVE bumps inside the window.

failure looks like:

```
✗ 1 entries younger than 7 days:
  foo@1.2.3
    published: 2026-XX-XXT14:00:00Z (2 days ago)
    mergeable after: 2026-XX-XXT14:00:00Z
```

advisory only until repo admin adds `Lockfile age audit / audit` as a required check on main. will follow up once this lands.

companion: #881.