### PR TITLE
Add ClickHouseSettingsInterface as a package-neutral settings type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 - (Node.js, `@experimental`) Added an additive `connection?: Connection<Stream.Readable>` option to `createClient` that lets a caller plug an externally-built backend `Connection`-like object in place of the default HTTP(S) factory. Only supposed to be used for testing the `chDB` integration. ([#879])
 
+- Added `ClickHouseSettingsInterface`, a package-neutral structural counterpart to `ClickHouseSettings`, exported from `@clickhouse/client`, `@clickhouse/client-web`, and `@clickhouse/client-common`. It is identical to `ClickHouseSettings` except that its index signature omits `SettingsMap` (a class with a private member, which TypeScript compares nominally). Because each client package now bundles its own copy of the common module, their `ClickHouseSettings` types are mutually unassignable; `ClickHouseSettingsInterface` is structurally identical across all three packages and assignable into each package's `ClickHouseSettings`, so a consumer that shares a single settings-producing helper across both the Node.js and Web clients can type it against this one type without casts. Values typed as `SettingsMap` cannot be carried through it — use `ClickHouseSettings` if you need them. ([#889])
+
 # 1.22.0
 
 ## New features
@@ -78,6 +80,7 @@ await client.query({
 [#828]: https://github.com/ClickHouse/clickhouse-js/pull/828
 [#845]: https://github.com/ClickHouse/clickhouse-js/pull/845
 [#864]: https://github.com/ClickHouse/clickhouse-js/pull/864
+[#889]: https://github.com/ClickHouse/clickhouse-js/pull/889
 
 ## Bug Fixes
 

--- a/packages/client-common/src/index.ts
+++ b/packages/client-common/src/index.ts
@@ -96,6 +96,7 @@ export {
 } from "./clickhouse_types";
 export {
   type ClickHouseSettings,
+  type ClickHouseSettingsInterface,
   type MergeTreeSettings,
   /** @deprecated Import `SettingsMap` from `@clickhouse/client` (Node.js) or `@clickhouse/client-web` (Web) instead. Importing it from `@clickhouse/client-common` is deprecated. */
   SettingsMap,

--- a/packages/client-common/src/settings.ts
+++ b/packages/client-common/src/settings.ts
@@ -1644,6 +1644,26 @@ export type ClickHouseSettings = Partial<ClickHouseServerSettings> &
   Partial<ClickHouseHTTPSettings> &
   Record<string, number | string | boolean | SettingsMap | undefined>;
 
+/**
+ * A package-neutral, structural view of {@link ClickHouseSettings}.
+ *
+ * Identical to {@link ClickHouseSettings} except that the index signature does
+ * not include {@link SettingsMap}. `SettingsMap` is a class with a private
+ * member, so TypeScript compares it nominally; because `@clickhouse/client` and
+ * `@clickhouse/client-web` each bundle their own copy of this module, their
+ * `ClickHouseSettings` types are mutually unassignable. This interface omits the
+ * only nominal member, so it is structurally identical across all three packages
+ * and assignable into each package's `ClickHouseSettings`.
+ *
+ * Intended for consumers that share a single settings-producing helper across
+ * both the Node.js and Web clients and therefore cannot import a single concrete
+ * `ClickHouseSettings`. Note: values typed as {@link SettingsMap} cannot be
+ * carried through this type — use {@link ClickHouseSettings} if you need them.
+ */
+export type ClickHouseSettingsInterface = Partial<ClickHouseServerSettings> &
+  Partial<ClickHouseHTTPSettings> &
+  Record<string, number | string | boolean | undefined>;
+
 export interface MergeTreeSettings {
   /** Allow floating point as partition key */
   allow_floating_point_partition_key?: Bool;

--- a/packages/client-node/src/index.ts
+++ b/packages/client-node/src/index.ts
@@ -30,6 +30,7 @@ export {
   type ErrorLogParams,
   type WarnLogParams,
   type ClickHouseSettings,
+  type ClickHouseSettingsInterface,
   type MergeTreeSettings,
   type Row,
   type ResponseJSON,

--- a/packages/client-web/src/index.ts
+++ b/packages/client-web/src/index.ts
@@ -29,6 +29,7 @@ export {
   type ErrorLogParams,
   type WarnLogParams,
   type ClickHouseSettings,
+  type ClickHouseSettingsInterface,
   type MergeTreeSettings,
   type Row,
   type ResponseJSON,

--- a/type-parser/mini-parser-ts/test/snapshots/05b87974a3b9b844.json
+++ b/type-parser/mini-parser-ts/test/snapshots/05b87974a3b9b844.json
@@ -37,10 +37,7 @@
                 ]
               }
             ],
-            "element_names": [
-              "a",
-              "b"
-            ]
+            "element_names": ["a", "b"]
           }
         ]
       }

--- a/type-parser/mini-parser-ts/test/snapshots/3badd67bde55d4f2.json
+++ b/type-parser/mini-parser-ts/test/snapshots/3badd67bde55d4f2.json
@@ -37,10 +37,7 @@
                 ]
               }
             ],
-            "element_names": [
-              "id",
-              "vals"
-            ]
+            "element_names": ["id", "vals"]
           }
         ]
       }

--- a/type-parser/mini-parser-ts/test/snapshots/3ce40017fe0513c0.json
+++ b/type-parser/mini-parser-ts/test/snapshots/3ce40017fe0513c0.json
@@ -20,10 +20,7 @@
               "name": "Float64"
             }
           ],
-          "element_names": [
-            "lat",
-            "lon"
-          ]
+          "element_names": ["lat", "lon"]
         }
       },
       {

--- a/type-parser/mini-parser-ts/test/snapshots/3d0564f65e2951d7.json
+++ b/type-parser/mini-parser-ts/test/snapshots/3d0564f65e2951d7.json
@@ -28,10 +28,7 @@
               "name": "Int8"
             }
           ],
-          "element_names": [
-            "x",
-            "y"
-          ]
+          "element_names": ["x", "y"]
         }
       }
     ]

--- a/type-parser/mini-parser-ts/test/snapshots/3d40c376159dc070.json
+++ b/type-parser/mini-parser-ts/test/snapshots/3d40c376159dc070.json
@@ -17,10 +17,6 @@
         "name": "String"
       }
     ],
-    "element_names": [
-      "first",
-      "second",
-      "third"
-    ]
+    "element_names": ["first", "second", "third"]
   }
 }

--- a/type-parser/mini-parser-ts/test/snapshots/4c5840cb7dad0940.json
+++ b/type-parser/mini-parser-ts/test/snapshots/4c5840cb7dad0940.json
@@ -21,11 +21,6 @@
         "name": "UInt64"
       }
     ],
-    "element_names": [
-      "a",
-      "b",
-      "c",
-      "d"
-    ]
+    "element_names": ["a", "b", "c", "d"]
   }
 }

--- a/type-parser/mini-parser-ts/test/snapshots/4d0c622ecdd58854.json
+++ b/type-parser/mini-parser-ts/test/snapshots/4d0c622ecdd58854.json
@@ -17,19 +17,13 @@
             "name": "UInt8"
           }
         ],
-        "element_names": [
-          "x",
-          "y"
-        ]
+        "element_names": ["x", "y"]
       },
       {
         "type": "DataType",
         "name": "String"
       }
     ],
-    "element_names": [
-      "a",
-      "b"
-    ]
+    "element_names": ["a", "b"]
   }
 }

--- a/type-parser/mini-parser-ts/test/snapshots/4e5e15828b576fc3.json
+++ b/type-parser/mini-parser-ts/test/snapshots/4e5e15828b576fc3.json
@@ -52,10 +52,7 @@
             ]
           }
         ],
-        "element_names": [
-          "a",
-          "b"
-        ]
+        "element_names": ["a", "b"]
       }
     ]
   }

--- a/type-parser/mini-parser-ts/test/snapshots/5bee16b592d3087c.json
+++ b/type-parser/mini-parser-ts/test/snapshots/5bee16b592d3087c.json
@@ -17,10 +17,6 @@
         "name": "Float64"
       }
     ],
-    "element_names": [
-      "id",
-      "name",
-      "score"
-    ]
+    "element_names": ["id", "name", "score"]
   }
 }

--- a/type-parser/mini-parser-ts/test/snapshots/6000a28977e029d9.json
+++ b/type-parser/mini-parser-ts/test/snapshots/6000a28977e029d9.json
@@ -34,10 +34,7 @@
               "name": "String"
             }
           ],
-          "element_names": [
-            "x",
-            "y"
-          ]
+          "element_names": ["x", "y"]
         }
       }
     ]

--- a/type-parser/mini-parser-ts/test/snapshots/63a53953382e5a76.json
+++ b/type-parser/mini-parser-ts/test/snapshots/63a53953382e5a76.json
@@ -13,9 +13,6 @@
         "name": "String"
       }
     ],
-    "element_names": [
-      "id",
-      "name"
-    ]
+    "element_names": ["id", "name"]
   }
 }

--- a/type-parser/mini-parser-ts/test/snapshots/6932c015a8c3a3ef.json
+++ b/type-parser/mini-parser-ts/test/snapshots/6932c015a8c3a3ef.json
@@ -41,16 +41,9 @@
             "name": "Int8"
           }
         ],
-        "element_names": [
-          "p",
-          "q"
-        ]
+        "element_names": ["p", "q"]
       }
     ],
-    "element_names": [
-      "a",
-      "b",
-      "c"
-    ]
+    "element_names": ["a", "b", "c"]
   }
 }

--- a/type-parser/mini-parser-ts/test/snapshots/6ddeb86eb863afac.json
+++ b/type-parser/mini-parser-ts/test/snapshots/6ddeb86eb863afac.json
@@ -47,17 +47,11 @@
                 "name": "Float64"
               }
             ],
-            "element_names": [
-              "ts",
-              "val"
-            ]
+            "element_names": ["ts", "val"]
           }
         ]
       }
     ],
-    "element_names": [
-      "meta",
-      "data"
-    ]
+    "element_names": ["meta", "data"]
   }
 }

--- a/type-parser/mini-parser-ts/test/snapshots/6e25d9b9f79612fd.json
+++ b/type-parser/mini-parser-ts/test/snapshots/6e25d9b9f79612fd.json
@@ -45,10 +45,7 @@
             ]
           }
         ],
-        "element_names": [
-          "created",
-          "tags"
-        ]
+        "element_names": ["created", "tags"]
       }
     ]
   }

--- a/type-parser/mini-parser-ts/test/snapshots/6e85b5501433e087.json
+++ b/type-parser/mini-parser-ts/test/snapshots/6e85b5501433e087.json
@@ -41,17 +41,10 @@
                 ]
               }
             ],
-            "element_names": [
-              "d",
-              "e"
-            ]
+            "element_names": ["d", "e"]
           }
         ],
-        "element_names": [
-          "a",
-          "b",
-          "c"
-        ]
+        "element_names": ["a", "b", "c"]
       }
     ]
   }

--- a/type-parser/mini-parser-ts/test/snapshots/711cbcac68f895ff.json
+++ b/type-parser/mini-parser-ts/test/snapshots/711cbcac68f895ff.json
@@ -49,15 +49,9 @@
             ]
           }
         ],
-        "element_names": [
-          "x",
-          "y"
-        ]
+        "element_names": ["x", "y"]
       }
     ],
-    "element_names": [
-      "a",
-      "b"
-    ]
+    "element_names": ["a", "b"]
   }
 }

--- a/type-parser/mini-parser-ts/test/snapshots/74219cbd9de3b122.json
+++ b/type-parser/mini-parser-ts/test/snapshots/74219cbd9de3b122.json
@@ -9,8 +9,6 @@
         "name": "UInt8"
       }
     ],
-    "element_names": [
-      "a"
-    ]
+    "element_names": ["a"]
   }
 }

--- a/type-parser/mini-parser-ts/test/snapshots/85e93d199ff62047.json
+++ b/type-parser/mini-parser-ts/test/snapshots/85e93d199ff62047.json
@@ -35,10 +35,6 @@
         ]
       }
     ],
-    "element_names": [
-      "a",
-      "b",
-      "c"
-    ]
+    "element_names": ["a", "b", "c"]
   }
 }

--- a/type-parser/mini-parser-ts/test/snapshots/ab56a84eb0f06b84.json
+++ b/type-parser/mini-parser-ts/test/snapshots/ab56a84eb0f06b84.json
@@ -17,10 +17,6 @@
         "name": "Bool"
       }
     ],
-    "element_names": [
-      "id",
-      "",
-      "flag"
-    ]
+    "element_names": ["id", "", "flag"]
   }
 }

--- a/type-parser/mini-parser-ts/test/snapshots/b306956d40529bf3.json
+++ b/type-parser/mini-parser-ts/test/snapshots/b306956d40529bf3.json
@@ -13,9 +13,6 @@
         "name": "String"
       }
     ],
-    "element_names": [
-      "a",
-      "b"
-    ]
+    "element_names": ["a", "b"]
   }
 }

--- a/type-parser/mini-parser-ts/test/snapshots/bad418ae7c592db2.json
+++ b/type-parser/mini-parser-ts/test/snapshots/bad418ae7c592db2.json
@@ -17,10 +17,6 @@
         "name": "Int32"
       }
     ],
-    "element_names": [
-      "x",
-      "y",
-      "z"
-    ]
+    "element_names": ["x", "y", "z"]
   }
 }

--- a/type-parser/mini-parser-ts/test/snapshots/cb3651f0a9fbe7c0.json
+++ b/type-parser/mini-parser-ts/test/snapshots/cb3651f0a9fbe7c0.json
@@ -19,9 +19,6 @@
         ]
       }
     ],
-    "element_names": [
-      "key",
-      "payload"
-    ]
+    "element_names": ["key", "payload"]
   }
 }

--- a/type-parser/mini-parser-ts/test/snapshots/d64027e56b998e7c.json
+++ b/type-parser/mini-parser-ts/test/snapshots/d64027e56b998e7c.json
@@ -17,10 +17,6 @@
         "name": "Float64"
       }
     ],
-    "element_names": [
-      "",
-      "b",
-      ""
-    ]
+    "element_names": ["", "b", ""]
   }
 }

--- a/type-parser/mini-parser-ts/test/snapshots/db09a2734af421e6.json
+++ b/type-parser/mini-parser-ts/test/snapshots/db09a2734af421e6.json
@@ -31,9 +31,6 @@
         ]
       }
     ],
-    "element_names": [
-      "ts",
-      "val"
-    ]
+    "element_names": ["ts", "val"]
   }
 }

--- a/type-parser/mini-parser-ts/test/snapshots/dd0748912e59ec25.json
+++ b/type-parser/mini-parser-ts/test/snapshots/dd0748912e59ec25.json
@@ -13,9 +13,6 @@
         "name": "String"
       }
     ],
-    "element_names": [
-      "a",
-      ""
-    ]
+    "element_names": ["a", ""]
   }
 }

--- a/type-parser/mini-parser-ts/test/snapshots/e2102781550b6a87.json
+++ b/type-parser/mini-parser-ts/test/snapshots/e2102781550b6a87.json
@@ -45,9 +45,6 @@
         ]
       }
     ],
-    "element_names": [
-      "v",
-      "arr"
-    ]
+    "element_names": ["v", "arr"]
   }
 }

--- a/type-parser/mini-parser-ts/test/snapshots/e227de9f1df532c1.json
+++ b/type-parser/mini-parser-ts/test/snapshots/e227de9f1df532c1.json
@@ -53,10 +53,7 @@
                     ]
                   }
                 ],
-                "element_names": [
-                  "a",
-                  "b"
-                ]
+                "element_names": ["a", "b"]
               }
             ]
           }

--- a/type-parser/mini-parser-ts/test/snapshots/e9ca4b2541b01556.json
+++ b/type-parser/mini-parser-ts/test/snapshots/e9ca4b2541b01556.json
@@ -13,9 +13,6 @@
         "name": "String"
       }
     ],
-    "element_names": [
-      "a",
-      "b"
-    ]
+    "element_names": ["a", "b"]
   }
 }

--- a/type-parser/mini-parser-ts/test/snapshots/effc93c8668219e9.json
+++ b/type-parser/mini-parser-ts/test/snapshots/effc93c8668219e9.json
@@ -17,10 +17,6 @@
         "name": "Polygon"
       }
     ],
-    "element_names": [
-      "p",
-      "r",
-      "poly"
-    ]
+    "element_names": ["p", "r", "poly"]
   }
 }

--- a/type-parser/mini-parser-ts/test/snapshots/fcf6d8ffa4297b9e.json
+++ b/type-parser/mini-parser-ts/test/snapshots/fcf6d8ffa4297b9e.json
@@ -17,10 +17,6 @@
         "name": "Float64"
       }
     ],
-    "element_names": [
-      "a",
-      "",
-      "c"
-    ]
+    "element_names": ["a", "", "c"]
   }
 }


### PR DESCRIPTION
## Summary

`ClickHouseSettings` includes `SettingsMap` (a class with a `private` member) in its index signature, so TypeScript compares it **nominally**. Since `@clickhouse/client` and `@clickhouse/client-web` each bundle their own copy of the common module, their `ClickHouseSettings` types are **mutually unassignable**. Consumers that share a single settings-producing helper across both the Node.js and Web clients therefore cannot type it against a single concrete `ClickHouseSettings`.

This adds **`ClickHouseSettingsInterface`** — identical to `ClickHouseSettings` but with `SettingsMap` omitted from the index-signature value union (the only nominal member). It is structurally identical across all three packages and assignable *into* each package's `ClickHouseSettings`, so a shared helper can return it and have it flow into both the node and web `client.query({ clickhouse_settings })` calls **without casts**.

Re-exported from `client-common`, `client-node`, and `client-web`.

## Why

A real consumer (HyperDX) has one shared `processClickhouseSettings()` that feeds both the node and web clients. After the client packages began bundling their own copy of common, the node and web `ClickHouseSettings` diverged nominally, breaking `tsc` (`TS2322`) and tripping `@typescript-eslint/no-unsafe-type-assertion` on the existing casts. A package-neutral settings type lets such consumers depend only on `@clickhouse/client` / `@clickhouse/client-web` and drop their `@clickhouse/client-common` dependency.

## Caveat

Values typed as `SettingsMap` cannot be carried through `ClickHouseSettingsInterface` — use `ClickHouseSettings` if you need them. No named setting field is typed as `SettingsMap`; it is reachable only via the catch-all index signature.

## Test plan

- [x] `tsc --noEmit` passes for `client-common`, `client-node`, and `client-web`