### PR TITLE
fix: make root postinstall resilient when parquet-wasm is absent

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "test:web:all": "TEST_MODE=all vitest -c vitest.web.config.ts",
     "test:web:coverage": "VITEST_COVERAGE=true TEST_MODE=all vitest -c vitest.web.config.ts",
     "//": "See https://github.com/kylebarron/parquet-wasm/issues/798",
-    "postinstall": "cd node_modules/parquet-wasm && npm pkg delete type",
+    "postinstall": "cd node_modules/parquet-wasm 2>/dev/null && npm pkg delete type || true",
     "prepare": "husky"
   },
   "devDependencies": {


### PR DESCRIPTION
## Problem

The `publish: datatype parser` workflow ([failing run](https://github.com/ClickHouse/clickhouse-js/actions/runs/28300601707/job/83848134306)) fails at the `npm ci` step:

```
sh: 1: cd: can't cd to node_modules/parquet-wasm
npm error command failed
npm error command sh -c cd node_modules/parquet-wasm && npm pkg delete type
```

The job runs `npm ci` with `working-directory: packages/datatype-parser`. Because that package has no lockfile of its own, npm resolves to the **root workspace** install, which fires the root `postinstall`. In that scoped install `parquet-wasm` (a test-only root devDependency, unrelated to the datatype-parser package) isn't present, so `cd node_modules/parquet-wasm` exits non-zero and aborts the whole install — the publish job never reaches its build step.

## Fix

Guard the root `postinstall` so it skips cleanly when `parquet-wasm` is absent instead of hard-failing:

```json
"postinstall": "cd node_modules/parquet-wasm 2>/dev/null && npm pkg delete type || true",
```

This is harmless for the normal full dev install (dir present → runs as before) and unblocks any `npm ci` that doesn't pull in `parquet-wasm`, including this publish workflow.

## Follow-up

The publish workflow dispatches from the protected `release` branch, so after this merges to `main`, `release` needs to be updated to the new snapshot before re-dispatching the publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)