### PR TITLE
fix(ci): install datatype-parser publish workspace from the repo root

### DIFF
--- a/.github/workflows/publish-datatype-parser.yml
+++ b/.github/workflows/publish-datatype-parser.yml
@@ -55,7 +55,13 @@ jobs:
           registry-url: "https://registry.npmjs.org"
 
       - name: Install dependencies
-        run: npm ci
+        # Run from the package dir, which resolves to the root workspace
+        # install. --ignore-scripts skips the root lifecycle scripts
+        # (postinstall/parquet-wasm, prepare/husky) that target dev-only
+        # devDependencies absent from this scoped install. The datatype-parser
+        # package itself has no install scripts; its build runs as a separate
+        # step below.
+        run: npm ci --ignore-scripts
 
       - name: Build
         run: npm run build

--- a/.github/workflows/publish-datatype-parser.yml
+++ b/.github/workflows/publish-datatype-parser.yml
@@ -55,13 +55,14 @@ jobs:
           registry-url: "https://registry.npmjs.org"
 
       - name: Install dependencies
-        # Run from the package dir, which resolves to the root workspace
-        # install. --ignore-scripts skips the root lifecycle scripts
-        # (postinstall/parquet-wasm, prepare/husky) that target dev-only
-        # devDependencies absent from this scoped install. The datatype-parser
-        # package itself has no install scripts; its build runs as a separate
-        # step below.
-        run: npm ci --ignore-scripts
+        # datatype-parser is an npm workspace package, so install the whole
+        # workspace from the repo root (overriding this job's package-dir
+        # default). A scoped `npm ci` from the package dir still fires the root
+        # lifecycle scripts (postinstall/parquet-wasm, prepare/husky) but
+        # without their dev-only devDependencies, which breaks the install. The
+        # remaining steps run from packages/datatype-parser as usual.
+        working-directory: ${{ github.workspace }}
+        run: npm ci
 
       - name: Build
         run: npm run build

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "test:web:all": "TEST_MODE=all vitest -c vitest.web.config.ts",
     "test:web:coverage": "VITEST_COVERAGE=true TEST_MODE=all vitest -c vitest.web.config.ts",
     "//": "See https://github.com/kylebarron/parquet-wasm/issues/798",
-    "postinstall": "cd node_modules/parquet-wasm 2>/dev/null && npm pkg delete type || true",
+    "postinstall": "cd node_modules/parquet-wasm && npm pkg delete type",
     "prepare": "husky"
   },
   "devDependencies": {


### PR DESCRIPTION
## Problem

The `publish: datatype parser` workflow ([failing run](https://github.com/ClickHouse/clickhouse-js/actions/runs/28301379782/job/83850177472)) fails at `npm ci`.

The workflow was ported from when `@clickhouse/datatype-parser` was a standalone repo, so it ran `npm ci` from the package dir (`packages/datatype-parser`). The package is now an **npm workspace** member, so a scoped install from the package dir resolves to the root workspace install and fires the root lifecycle scripts — but without the dev-only root devDependencies those scripts need:

- `postinstall` → `parquet-wasm`
- `prepare` → `husky`:
  ```
  > husky
  sh: 1: husky: not found
  npm error code 127
  ```

## Fix

Install the whole workspace from the **repo root** (override the job's package-dir default for just the install step). The build/pack/publish steps still run from `packages/datatype-parser`. This is the correct workspace-aware install and lets the root lifecycle scripts run with their devDependencies present.

Also reverts the #897 postinstall guard, which was a workaround for the now-fixed scoped-install problem; the original strict form fails loudly if `parquet-wasm` is ever genuinely missing.

## Verification (local, Node 24 matching CI)

- plain scoped `npm ci` from `packages/datatype-parser` → reproduces the `husky` exit 127 failure
- root `npm ci` → installs full workspace; strict `postinstall` (parquet-wasm) and `prepare` (husky) both run cleanly
- `npm run build` (tsc) from the package dir → OK
- `npm pack` + install tarball + `import { parseDataType }` smoke test → "imports cleanly"

## Follow-up

The publish workflow dispatches from the protected `release` branch, so after this merges to `main`, `release` needs to be updated to the new snapshot before re-dispatching the publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)