### PR TITLE
ci: raise npm fetch retries to de-flake installs

### DIFF
--- a/.github/workflows/e2e-skills.yml
+++ b/.github/workflows/e2e-skills.yml
@@ -18,6 +18,14 @@ on:
     branches:
       - release
 
+env:
+  # Network resilience: npm's default of 2 fetch retries is not enough for
+  # the transient registry errors (ECONNRESET) we regularly hit in CI.
+  NPM_CONFIG_FETCH_RETRIES: "5"
+  NPM_CONFIG_FETCH_RETRY_MINTIMEOUT: "10000"
+  NPM_CONFIG_FETCH_RETRY_MAXTIMEOUT: "60000"
+  NPM_CONFIG_FETCH_TIMEOUT: "600000"
+
 jobs:
   skills-packaging:
     runs-on: ubuntu-latest

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -50,6 +50,12 @@ env:
   OTEL_RESOURCE_ATTRIBUTES: "service.namespace=clickhouse-js,deployment.environment=ci"
   VITEST_OTEL_ENABLED: "true"
   VITEST_COVERAGE: "true"
+  # Network resilience: npm's default of 2 fetch retries is not enough for
+  # the transient registry errors (ECONNRESET) we regularly hit in CI.
+  NPM_CONFIG_FETCH_RETRIES: "5"
+  NPM_CONFIG_FETCH_RETRY_MINTIMEOUT: "10000"
+  NPM_CONFIG_FETCH_RETRY_MAXTIMEOUT: "60000"
+  NPM_CONFIG_FETCH_TIMEOUT: "600000"
 
 jobs:
   code-quality:

--- a/.github/workflows/publish-datatype-parser.yml
+++ b/.github/workflows/publish-datatype-parser.yml
@@ -28,6 +28,14 @@ concurrency:
 on:
   workflow_dispatch:
 
+env:
+  # Network resilience: npm's default of 2 fetch retries is not enough for
+  # the transient registry errors (ECONNRESET) we regularly hit in CI.
+  NPM_CONFIG_FETCH_RETRIES: "5"
+  NPM_CONFIG_FETCH_RETRY_MINTIMEOUT: "10000"
+  NPM_CONFIG_FETCH_RETRY_MAXTIMEOUT: "60000"
+  NPM_CONFIG_FETCH_TIMEOUT: "600000"
+
 jobs:
   publish:
     # The npm-publish environment only permits the release branch to deploy;

--- a/.github/workflows/publish-skill-rowbinary-parser.yml
+++ b/.github/workflows/publish-skill-rowbinary-parser.yml
@@ -28,6 +28,14 @@ concurrency:
 on:
   workflow_dispatch:
 
+env:
+  # Network resilience: npm's default of 2 fetch retries is not enough for
+  # the transient registry errors (ECONNRESET) we regularly hit in CI.
+  NPM_CONFIG_FETCH_RETRIES: "5"
+  NPM_CONFIG_FETCH_RETRY_MINTIMEOUT: "10000"
+  NPM_CONFIG_FETCH_RETRY_MAXTIMEOUT: "60000"
+  NPM_CONFIG_FETCH_TIMEOUT: "600000"
+
 jobs:
   publish:
     # The npm-publish environment only permits the release branch to deploy;

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -64,6 +64,14 @@ on:
       - "skills/**"
       - ".github/workflows/publish.yml"
 
+env:
+  # Network resilience: npm's default of 2 fetch retries is not enough for
+  # the transient registry errors (ECONNRESET) we regularly hit in CI.
+  NPM_CONFIG_FETCH_RETRIES: "5"
+  NPM_CONFIG_FETCH_RETRY_MINTIMEOUT: "10000"
+  NPM_CONFIG_FETCH_RETRY_MAXTIMEOUT: "60000"
+  NPM_CONFIG_FETCH_TIMEOUT: "600000"
+
 jobs:
   head_client:
     name: "Publish @clickhouse/client (head)"

--- a/.github/workflows/tests-node.yml
+++ b/.github/workflows/tests-node.yml
@@ -51,6 +51,12 @@ env:
   OTEL_RESOURCE_ATTRIBUTES: "service.namespace=clickhouse-js,deployment.environment=ci"
   VITEST_OTEL_ENABLED: "true"
   VITEST_COVERAGE: "true"
+  # Network resilience: npm's default of 2 fetch retries is not enough for
+  # the transient registry errors (ECONNRESET) we regularly hit in CI.
+  NPM_CONFIG_FETCH_RETRIES: "5"
+  NPM_CONFIG_FETCH_RETRY_MINTIMEOUT: "10000"
+  NPM_CONFIG_FETCH_RETRY_MAXTIMEOUT: "60000"
+  NPM_CONFIG_FETCH_TIMEOUT: "600000"
 
 jobs:
   code-quality:

--- a/.github/workflows/tests-oss-dependents.yml
+++ b/.github/workflows/tests-oss-dependents.yml
@@ -44,6 +44,14 @@ concurrency:
   group: "${{ github.workflow }}-${{ github.ref }}"
   cancel-in-progress: true
 
+env:
+  # Network resilience: npm's default of 2 fetch retries is not enough for
+  # the transient registry errors (ECONNRESET) we regularly hit in CI.
+  NPM_CONFIG_FETCH_RETRIES: "5"
+  NPM_CONFIG_FETCH_RETRY_MINTIMEOUT: "10000"
+  NPM_CONFIG_FETCH_RETRY_MAXTIMEOUT: "60000"
+  NPM_CONFIG_FETCH_TIMEOUT: "600000"
+
 jobs:
   # Runnable reproductions of how the top OSS dependents use the client, resolved
   # against the workspace source via the @clickhouse/client* vitest aliases. This

--- a/.github/workflows/tests-skill-rowbinary-parser.yml
+++ b/.github/workflows/tests-skill-rowbinary-parser.yml
@@ -22,6 +22,14 @@ concurrency:
   group: "${{ github.workflow }}-${{ github.ref }}"
   cancel-in-progress: true
 
+env:
+  # Network resilience: npm's default of 2 fetch retries is not enough for
+  # the transient registry errors (ECONNRESET) we regularly hit in CI.
+  NPM_CONFIG_FETCH_RETRIES: "5"
+  NPM_CONFIG_FETCH_RETRY_MINTIMEOUT: "10000"
+  NPM_CONFIG_FETCH_RETRY_MAXTIMEOUT: "60000"
+  NPM_CONFIG_FETCH_TIMEOUT: "600000"
+
 jobs:
   typecheck:
     timeout-minutes: 5

--- a/.github/workflows/tests-web.yml
+++ b/.github/workflows/tests-web.yml
@@ -51,6 +51,12 @@ env:
   OTEL_RESOURCE_ATTRIBUTES: "service.namespace=clickhouse-js,deployment.environment=ci"
   VITEST_OTEL_ENABLED: "true"
   VITEST_COVERAGE: "true"
+  # Network resilience: npm's default of 2 fetch retries is not enough for
+  # the transient registry errors (ECONNRESET) we regularly hit in CI.
+  NPM_CONFIG_FETCH_RETRIES: "5"
+  NPM_CONFIG_FETCH_RETRY_MINTIMEOUT: "10000"
+  NPM_CONFIG_FETCH_RETRY_MAXTIMEOUT: "60000"
+  NPM_CONFIG_FETCH_TIMEOUT: "600000"
 
 jobs:
   common-unit-tests:

--- a/.github/workflows/upstream-sql-tests.yml
+++ b/.github/workflows/upstream-sql-tests.yml
@@ -29,6 +29,12 @@ concurrency:
 
 env:
   UPSTREAM_REPO: "ClickHouse/ClickHouse"
+  # Network resilience: npm's default of 2 fetch retries is not enough for
+  # the transient registry errors (ECONNRESET) we regularly hit in CI.
+  NPM_CONFIG_FETCH_RETRIES: "5"
+  NPM_CONFIG_FETCH_RETRY_MINTIMEOUT: "10000"
+  NPM_CONFIG_FETCH_RETRY_MAXTIMEOUT: "60000"
+  NPM_CONFIG_FETCH_TIMEOUT: "600000"
 
 jobs:
   upstream-sql-tests:


### PR DESCRIPTION
## Problem

CI install steps fail intermittently with transient registry errors, e.g. the `ECONNRESET` seen on #900:

```
npm error code ECONNRESET
npm error network aborted
npm error network This is a problem related to network connectivity.
```

npm's default is only **2** network retries, so a single connection reset mid-download fails the entire `npm ci` / `npm install` step and the job.

## Fix

Raise npm's fetch retry count and timeouts via top-level workflow `env` in every workflow that installs dependencies:

```yaml
NPM_CONFIG_FETCH_RETRIES: "5"
NPM_CONFIG_FETCH_RETRY_MINTIMEOUT: "10000"
NPM_CONFIG_FETCH_RETRY_MAXTIMEOUT: "60000"
NPM_CONFIG_FETCH_TIMEOUT: "600000"
```

Applied as workflow env vars rather than a committed `.npmrc`, because `.npmrc` is gitignored as a token-leak guard (kept that convention intact).

### Scope

10 workflows that run `npm ci`/`npm install`: `publish.yml`, `tests-node.yml`, `tests-web.yml`, `tests-oss-dependents.yml`, `tests-skill-rowbinary-parser.yml`, `publish-datatype-parser.yml`, `publish-skill-rowbinary-parser.yml`, `e2e-skills.yml`, `examples.yml`, `upstream-sql-tests.yml`.

`tests-bun.yml` is intentionally excluded — `bun install` does not read `NPM_CONFIG_*` env vars.

## Verification

- Confirmed the env-var mapping locally: `NPM_CONFIG_FETCH_RETRIES=7 npm config get fetch-retries` → `fetch-retries=7` (and the same for the timeout keys).
- All 10 edited workflows parse as valid YAML with exactly the 4 `NPM_CONFIG_*` keys under top-level `env`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)