### PR TITLE
fix(e2e): keep post-publish integration.ts free of TS-only syntax (Node 20)

### DIFF
--- a/tests/e2e/install/src/integration.ts
+++ b/tests/e2e/install/src/integration.ts
@@ -7,33 +7,34 @@
 // publish workflow's e2e job (which installs the package by its published
 // version and starts a single-node ClickHouse), so it validates the actual npm
 // tarball a consumer would receive, not the local build.
+//
+// NOTE: this file is run via `node src/integration.ts` across Node 20/22/24.
+// Node 20 does not strip TypeScript types, so this must stay free of TS-only
+// syntax (no type annotations, `as` casts, etc.) — plain JS in a .ts file, like
+// src/index.ts.
 const assert = require("assert");
 const { createClient, ClickHouseError } = require("@clickhouse/client");
-
-// The e2e job starts ClickHouse via docker-compose just before this runs; poll
-// ping briefly so we don't race the container coming up.
-async function waitForClickHouse(client: any) {
-  const maxAttempts = 30;
-  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
-    try {
-      const res = await client.ping();
-      if (res.success) return;
-    } catch {
-      // not ready yet
-    }
-    if (attempt === maxAttempts) {
-      throw new Error("ClickHouse did not become available in time");
-    }
-    await new Promise((resolve) => setTimeout(resolve, 1000));
-  }
-}
 
 async function main() {
   // Defaults target http://localhost:8123 with the default user, matching the
   // single-node `clickhouse` service from docker-compose.yml.
   const client = createClient();
   try {
-    await waitForClickHouse(client);
+    // The e2e job starts ClickHouse via docker-compose just before this runs;
+    // poll ping briefly so we don't race the container coming up.
+    const maxAttempts = 30;
+    for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+      try {
+        const res = await client.ping();
+        if (res.success) break;
+      } catch {
+        // not ready yet
+      }
+      if (attempt === maxAttempts) {
+        throw new Error("ClickHouse did not become available in time");
+      }
+      await new Promise((resolve) => setTimeout(resolve, 1000));
+    }
 
     const table = `e2e_install_${Date.now()}`;
     await client.command({
@@ -71,7 +72,7 @@ async function main() {
 
     // A bad query must surface as a ClickHouseError instance from the SAME
     // installed package (a single bundle => one class identity).
-    let caught: unknown;
+    let caught;
     try {
       await client.query({
         query: "SELECT * FROM table_that_does_not_exist_e2e",


### PR DESCRIPTION
## Summary

Fixes the `e2e (node 20)` failure in the `publish` workflow ([run](https://github.com/ClickHouse/clickhouse-js/actions/runs/28302399799/job/83852950182)):

```
tests/e2e/install/src/integration.ts:15
SyntaxError: Unexpected token ':'
```

`tests/e2e/install/src/integration.ts` (added in #899) is run via `node src/integration.ts` across Node 20/22/24. **Node 20 does not strip TypeScript types by default** (that became default only in 22.18 / 23.6), so the `client: any` and `caught: unknown` annotations were a hard syntax error on the Node 20 leg. `src/index.ts` survives because it's plain JS in a `.ts` file.

### Fix
Make `integration.ts` TS-syntax-free, like `src/index.ts`:
- Inline the ping-wait loop into `main()`, removing the annotated `waitForClickHouse(client: any)` parameter (this also keeps the strict `tsc --noEmit` step happy — no implicit `any`, since there's no longer a parameter to annotate).
- Drop the `let caught: unknown` annotation.

Behaviour is unchanged.

## Verification
- `grep` confirms no TS-only syntax remains.
- `tsc --noEmit` (strict) passes in `tests/e2e/install`.
- Ran `node src/integration.ts` against the real published `@clickhouse/client` + a local ClickHouse — exit 0, all assertions pass.
- The plain-JS-in-`.ts` pattern matches `src/index.ts`, which already runs on the Node 20 leg.

🤖 Generated with [Claude Code](https://claude.com/claude-code)