### PR TITLE
ci: support Node.js 26, drop Node.js 18

### DIFF
--- a/.claude/skills/setup/SKILL.md
+++ b/.claude/skills/setup/SKILL.md
@@ -20,7 +20,7 @@ Use this skill before running any of the `npm run test:*`, `npm run lint`, `npm 
 
 ## Prerequisites
 
-- **Node.js 22 recommended** (matches `.nvmrc`). The root `package.json` declares `"engines": { "node": ">=20.19.0" }`, and CI tests Node 20, 22, and 24.
+- **Node.js 22 recommended** (matches `.nvmrc`). The root `package.json` declares `"engines": { "node": ">=20.19.0" }`, and CI tests Node 20, 22, 24, and 26.
 - **Docker** with the Compose plugin (`docker compose ...`). Required only for integration tests and any example that talks to a real server.
 
 ## 1. Install dependencies

--- a/.github/workflows/publish-datatype-parser.yml
+++ b/.github/workflows/publish-datatype-parser.yml
@@ -137,7 +137,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        node: [20, 22, 24]
+        node: [20, 22, 24, 26]
     env:
       PUBLISHED_VERSION: ${{ needs.publish.outputs.version }}
     steps:

--- a/.github/workflows/publish-skill-rowbinary-parser.yml
+++ b/.github/workflows/publish-skill-rowbinary-parser.yml
@@ -132,7 +132,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        node: [20, 22, 24]
+        node: [20, 22, 24, 26]
     env:
       PUBLISHED_VERSION: ${{ needs.publish.outputs.version }}
     steps:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -339,7 +339,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        node: [20, 22, 24]
+        node: [20, 22, 24, 26]
     defaults:
       run:
         working-directory: tests/e2e/install

--- a/.github/workflows/tests-node.yml
+++ b/.github/workflows/tests-node.yml
@@ -106,7 +106,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [20, 22, 24]
+        node: [20, 22, 24, 26]
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
@@ -148,7 +148,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [20, 22, 24]
+        node: [20, 22, 24, 26]
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
@@ -195,7 +195,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [20, 22, 24]
+        node: [20, 22, 24, 26]
         clickhouse: [head, latest]
         log_level: [undefined, TRACE]
         include:
@@ -269,7 +269,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [20, 22, 24]
+        node: [20, 22, 24, 26]
         clickhouse: [head, latest]
 
     steps:
@@ -323,7 +323,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [20, 22, 24]
+        node: [20, 22, 24, 26]
 
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3

--- a/.github/workflows/tests-oss-dependents.yml
+++ b/.github/workflows/tests-oss-dependents.yml
@@ -64,7 +64,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [20, 22, 24]
+        node: [20, 22, 24, 26]
 
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3

--- a/.github/workflows/tests-skill-rowbinary-parser.yml
+++ b/.github/workflows/tests-skill-rowbinary-parser.yml
@@ -73,7 +73,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [20, 22, 24]
+        node: [20, 22, 24, 26]
         clickhouse: [head, latest]
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Migration Notes
 
+- Node.js 26.x was added to the CI matrix, and Node.js 18.x is no longer supported. The `engines.node` floor of `@clickhouse/client` (previously `>=16`) and `@clickhouse/datatype-parser` (previously `>=18.0.0`) was raised to `>=20`. Node.js 20.x, 22.x, 24.x, and 26.x are supported and exercised in CI.
+
 - The `@clickhouse/client-common` package is deprecated. `@clickhouse/client` (Node.js) and `@clickhouse/client-web` (Web) no longer depend on it; the shared code is now bundled into each client package. Everything previously importable from `@clickhouse/client-common` should be imported from `@clickhouse/client` or `@clickhouse/client-web` instead. The `@clickhouse/client-common` package itself will no longer receive updates. ([#845])
 
 - The `parseColumnType` function and its `SimpleColumnTypes` companion (exported from `@clickhouse/client`, `@clickhouse/client-web`, and `@clickhouse/client-common`) are deprecated and slated for removal in a future major version. They are superseded by the new standalone [`@clickhouse/datatype-parser`](https://www.npmjs.com/package/@clickhouse/datatype-parser) package (`parseDataType` plus its `Node` AST), which parses the full ClickHouse data-type grammar and emits an AST that mirrors the server's. ([#893])

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,7 @@ and help us maintain up-to-date documentation.
 
 You have installed:
 
-- a compatible LTS version of Node.js: `v20.x`, `v22.x`, `v24.x` or `v26.x`
+- a compatible version of Node.js: `v20.x`, `v22.x`, `v24.x` or `v26.x`
 - NPM >= `9.x`
 
 ### Create a fork of the repository and clone it

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,7 @@ and help us maintain up-to-date documentation.
 
 You have installed:
 
-- a compatible LTS version of Node.js: `v20.x`, `v22.x` or `v24.x`
+- a compatible LTS version of Node.js: `v20.x`, `v22.x`, `v24.x` or `v26.x`
 - NPM >= `9.x`
 
 ### Create a fork of the repository and clone it

--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ Node.js must be available in the environment to run the Node.js client. The clie
 
 | Node.js version | Supported?  |
 | --------------- | ----------- |
+| 26.x            | ✔           |
 | 24.x            | ✔           |
 | 22.x            | ✔           |
 | 20.x            | ✔           |

--- a/README.md
+++ b/README.md
@@ -63,12 +63,12 @@ npm i @clickhouse/client-web
 
 Node.js must be available in the environment to run the Node.js client. The client is compatible with all the [maintained](https://github.com/nodejs/release#readme) Node.js releases.
 
-| Node.js version | Supported?  |
-| --------------- | ----------- |
-| 26.x            | ✔           |
-| 24.x            | ✔           |
-| 22.x            | ✔           |
-| 20.x            | ✔           |
+| Node.js version | Supported? |
+| --------------- | ---------- |
+| 26.x            | ✔          |
+| 24.x            | ✔          |
+| 22.x            | ✔          |
+| 20.x            | ✔          |
 
 ### TypeScript
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,6 @@ Node.js must be available in the environment to run the Node.js client. The clie
 | 24.x            | ✔           |
 | 22.x            | ✔           |
 | 20.x            | ✔           |
-| 18.x            | Best effort |
 
 ### TypeScript
 

--- a/demo/logs/README.md
+++ b/demo/logs/README.md
@@ -34,7 +34,7 @@ hot path.
 
 ## Prerequisites
 
-- Node 18+ (built/tested on Node 24)
+- Node 20+ (built/tested on Node 24)
 - A running ClickHouse. This demo ships a self-contained one — from **this
   directory** (`demo/logs`):
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -159,7 +159,7 @@ deployment-shaped connection strings.
 
 Environment requirements for all examples:
 
-- Node.js 18+
+- Node.js 20+
 - NPM
 - Docker Compose
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -7710,7 +7710,7 @@
         "simdjson": "^0.9.2"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=20"
       }
     },
     "packages/client-web": {
@@ -7728,7 +7728,7 @@
         "vitest": "^4.0.16"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20"
       }
     },
     "packages/datatype-parser/node_modules/typescript": {

--- a/packages/client-node/package.json
+++ b/packages/client-node/package.json
@@ -15,7 +15,7 @@
   },
   "private": false,
   "engines": {
-    "node": ">=16"
+    "node": ">=20"
   },
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/datatype-parser/package.json
+++ b/packages/datatype-parser/package.json
@@ -19,7 +19,7 @@
   ],
   "sideEffects": false,
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=20"
   },
   "repository": {
     "type": "git",

--- a/skills/clickhouse-js-node-rowbinary-parser/README.md
+++ b/skills/clickhouse-js-node-rowbinary-parser/README.md
@@ -109,7 +109,12 @@ import {
 } from "@clickhouse/rowbinary";
 import { createClient } from "@clickhouse/client";
 
-type OrderRow = { id: number; uid: string; price: DecimalValue; status: number };
+type OrderRow = {
+  id: number;
+  uid: string;
+  price: DecimalValue;
+  status: number;
+};
 
 const readOrderRow: Reader<OrderRow> = (s) => ({
   id: readUInt8(s),


### PR DESCRIPTION
## Summary

Refresh the supported Node.js policy: add Node 26 and drop the EOL Node 18. Node 20 stays fully supported (CI + engines).

### Node 26
- Added `26` to every Node.js test/e2e matrix (`tests-node` ×5, `publish`, `tests-oss-dependents`, `tests-skill-rowbinary-parser`, `publish-skill-rowbinary-parser`, `publish-datatype-parser`) → `[20, 22, 24, 26]`.

### Drop Node 18
- README support table: removed the `18.x` row (20.x remains ✔).
- Raised the `engines.node` floor of the published **`@clickhouse/client`** (`>=16` → `>=20`) and **`@clickhouse/datatype-parser`** (`>=18.0.0` → `>=20`), with matching `package-lock.json` updates (workspace entries only — transitive deps untouched). Other manifests already required `>=20`.
- Updated CONTRIBUTING, the setup skill, the example/demo prerequisites, and added a CHANGELOG migration note.

> [!NOTE]
> Raising `engines.node` on the published `@clickhouse/client` (was `>=16`) and `@clickhouse/datatype-parser` (was `>=18.0.0`) is user-facing — installs on Node <20 will now emit an `EBADENGINE` warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)