### PR TITLE
test(upstream): honor serverError/clientError hints in the SQL test runner

### DIFF
--- a/tests/clickhouse-test-runner/__tests__/test-hint.test.ts
+++ b/tests/clickhouse-test-runner/__tests__/test-hint.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildStatements,
+  errorMatchesExpectation,
+  parseHintComment,
+} from "../src/test-hint.js";
+import { splitQueries } from "../src/split-queries.js";
+
+const statements = (sql: string) => buildStatements(splitQueries(sql));
+
+describe("parseHintComment", () => {
+  it("parses a named serverError hint", () => {
+    const hint = parseHintComment(
+      "-- { serverError SIZES_OF_ARRAYS_DONT_MATCH }",
+    );
+    expect(hint).not.toBeNull();
+    expect([...hint!.names]).toEqual(["SIZES_OF_ARRAYS_DONT_MATCH"]);
+    expect([...hint!.codes]).toEqual([]);
+    expect(hint!.label).toBe("serverError SIZES_OF_ARRAYS_DONT_MATCH");
+  });
+
+  it("parses a numeric serverError hint", () => {
+    const hint = parseHintComment("-- { serverError 190 }");
+    expect([...hint!.codes]).toEqual(["190"]);
+    expect([...hint!.names]).toEqual([]);
+  });
+
+  it("parses a comma-separated list of codes", () => {
+    const hint = parseHintComment("-- { serverError 153, 6 }");
+    expect([...hint!.codes].sort()).toEqual(["153", "6"]);
+  });
+
+  it("parses a clientError hint", () => {
+    const hint = parseHintComment("-- { clientError SYNTAX_ERROR }");
+    expect([...hint!.names]).toEqual(["SYNTAX_ERROR"]);
+  });
+
+  it("supports block comments", () => {
+    const hint = parseHintComment("/* { serverError 241 } */");
+    expect([...hint!.codes]).toEqual(["241"]);
+  });
+
+  it("returns null for non-error hints", () => {
+    expect(parseHintComment("-- { echoOn }")).toBeNull();
+    expect(parseHintComment("-- a plain comment")).toBeNull();
+    expect(parseHintComment("-- { unterminated")).toBeNull();
+  });
+});
+
+describe("buildStatements", () => {
+  it("leaves un-annotated statements without an expectation", () => {
+    expect(statements("SELECT 1; SELECT 2")).toEqual([
+      { sql: "SELECT 1", expectedError: null },
+      { sql: "SELECT 2", expectedError: null },
+    ]);
+  });
+
+  it("attaches a trailing hint to the preceding statement", () => {
+    expect(
+      statements(
+        "SELECT throwIf(1); -- { serverError FUNCTION_THROW_IF_VALUE_IS_NON_ZERO }\nSELECT 2;",
+      ),
+    ).toEqual([
+      {
+        sql: "SELECT throwIf(1)",
+        expectedError: {
+          label: "serverError FUNCTION_THROW_IF_VALUE_IS_NON_ZERO",
+          codes: new Set(),
+          names: new Set(["FUNCTION_THROW_IF_VALUE_IS_NON_ZERO"]),
+        },
+      },
+      {
+        sql: "-- { serverError FUNCTION_THROW_IF_VALUE_IS_NON_ZERO }\nSELECT 2",
+        expectedError: null,
+      },
+    ]);
+  });
+
+  it("attaches a hint left dangling after the final statement", () => {
+    expect(statements("SELECT bad(); -- { serverError 42 }")).toEqual([
+      {
+        sql: "SELECT bad()",
+        expectedError: {
+          label: "serverError 42",
+          codes: new Set(["42"]),
+          names: new Set(),
+        },
+      },
+    ]);
+  });
+
+  it("ignores a leading hint with no preceding statement", () => {
+    expect(statements("-- { serverError 42 }\nSELECT 1;")).toEqual([
+      { sql: "-- { serverError 42 }\nSELECT 1", expectedError: null },
+    ]);
+  });
+
+  it("attaches consecutive hints to their own statements", () => {
+    const result = statements(
+      "SELECT a; -- { serverError 1 }\nSELECT b; -- { serverError 2 }\nSELECT c;",
+    );
+    expect(result.map((s) => s.sql.includes("SELECT a"))).toContain(true);
+    const a = result.find((s) => s.sql.endsWith("SELECT a"))!;
+    const b = result.find((s) => s.sql.includes("SELECT b"))!;
+    const c = result.find((s) => s.sql.includes("SELECT c"))!;
+    expect([...a.expectedError!.codes]).toEqual(["1"]);
+    expect([...b.expectedError!.codes]).toEqual(["2"]);
+    expect(c.expectedError).toBeNull();
+  });
+});
+
+describe("errorMatchesExpectation", () => {
+  const expected = parseHintComment(
+    "-- { serverError SIZES_OF_ARRAYS_DONT_MATCH }",
+  )!;
+
+  it("matches by error type name", () => {
+    expect(
+      errorMatchesExpectation(
+        { code: "190", type: "SIZES_OF_ARRAYS_DONT_MATCH" },
+        expected,
+      ),
+    ).toBe(true);
+  });
+
+  it("matches by numeric code", () => {
+    const byCode = parseHintComment("-- { serverError 190 }")!;
+    expect(errorMatchesExpectation({ code: "190" }, byCode)).toBe(true);
+    expect(errorMatchesExpectation({ code: 190 }, byCode)).toBe(true);
+  });
+
+  it("does not match a different error", () => {
+    expect(
+      errorMatchesExpectation({ code: "60", type: "UNKNOWN_TABLE" }, expected),
+    ).toBe(false);
+  });
+
+  it("does not match non-error values", () => {
+    expect(errorMatchesExpectation(null, expected)).toBe(false);
+    expect(errorMatchesExpectation("boom", expected)).toBe(false);
+  });
+});

--- a/tests/clickhouse-test-runner/src/backends/client.ts
+++ b/tests/clickhouse-test-runner/src/backends/client.ts
@@ -1,11 +1,12 @@
 import { randomUUID } from "node:crypto";
-import { createClient } from "@clickhouse/client";
+import { ClickHouseLogLevel, createClient } from "@clickhouse/client";
 import type { ParsedArgs } from "../args.js";
 import { appendLog } from "../log.js";
+import { errorMatchesExpectation, type Statement } from "../test-hint.js";
 
 export interface BackendOptions {
   args: ParsedArgs;
-  queries: string[];
+  statements: Statement[];
   logPath: string;
 }
 
@@ -30,7 +31,7 @@ function buildClickHouseSettings(
 }
 
 export async function executeWithClient(opts: BackendOptions): Promise<void> {
-  const { args, queries, logPath } = opts;
+  const { args, statements, logPath } = opts;
   const proto = args.secure ? "https" : "http";
   const url = `${proto}://${args.host}:${args.port}`;
   // Use a dedicated per-invocation session_id so that settings applied via
@@ -48,25 +49,58 @@ export async function executeWithClient(opts: BackendOptions): Promise<void> {
     password: args.password,
     database: args.database,
     session_id: sessionId,
+    // The client logs request errors to stderr by default. We surface failures
+    // ourselves (and deliberately swallow errors matched by a `-- { serverError
+    // ... }` hint), and upstream `clickhouse-test` fails any test that writes to
+    // stderr — so keep the client itself silent.
+    log: { level: ClickHouseLogLevel.OFF },
   });
 
   const clickhouse_settings = buildClickHouseSettings(args);
 
   try {
-    for (const q of queries) {
-      appendLog(logPath, "executing_query=" + q);
-      const result = await client.exec({
-        query: q,
-        clickhouse_settings,
-      });
-      for await (const chunk of result.stream) {
-        process.stdout.write(chunk);
+    for (const stmt of statements) {
+      appendLog(logPath, "executing_query=" + stmt.sql);
+      let execError: unknown = null;
+      try {
+        const result = await client.exec({
+          query: stmt.sql,
+          clickhouse_settings,
+        });
+        for await (const chunk of result.stream) {
+          process.stdout.write(chunk);
+        }
+      } catch (err) {
+        execError = err;
+      }
+
+      const expected = stmt.expectedError;
+      if (expected !== null) {
+        // The statement is annotated with `-- { serverError ... }`: an error is
+        // the success path, and the absence of one is a failure.
+        if (execError === null) {
+          throw new Error(
+            `Expected error (${expected.label}) but the query succeeded: ${stmt.sql}`,
+          );
+        }
+        if (!errorMatchesExpectation(execError, expected)) {
+          const actual =
+            execError instanceof Error ? execError.message : String(execError);
+          throw new Error(
+            `Expected error (${expected.label}) but got a different error: ${actual}`,
+          );
+        }
+        appendLog(logPath, "expected_error_matched=" + expected.label);
+        continue;
+      }
+
+      if (execError !== null) {
+        const msg =
+          execError instanceof Error ? execError.message : String(execError);
+        appendLog(logPath, "error=" + msg);
+        throw execError;
       }
     }
-  } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err);
-    appendLog(logPath, "error=" + msg);
-    throw err;
   } finally {
     await client.close();
   }

--- a/tests/clickhouse-test-runner/src/main.ts
+++ b/tests/clickhouse-test-runner/src/main.ts
@@ -3,6 +3,7 @@ import { readFileSync } from "node:fs";
 import { parseArgs, printUsage } from "./args.js";
 import { appendLog, resolveLogPath, safeForLog } from "./log.js";
 import { splitQueries } from "./split-queries.js";
+import { buildStatements, type Statement } from "./test-hint.js";
 import { handleExtractFromConfig } from "./extract-from-config.js";
 import { executeWithClient } from "./backends/client.js";
 
@@ -51,12 +52,14 @@ async function main(): Promise<void> {
     return;
   }
 
-  const queries = args.multiquery ? splitQueries(query) : [query.trim()];
-  if (queries.length === 0) {
-    process.stderr.write(
-      "No query provided. Use --query or pipe SQL via stdin.\n",
-    );
-    process.exitCode = 1;
+  const statements: Statement[] = args.multiquery
+    ? buildStatements(splitQueries(query))
+    : [{ sql: query.trim(), expectedError: null }];
+  if (statements.length === 0) {
+    // The input contained only comments/whitespace (e.g. a leftover error
+    // hint after the final statement). Nothing to run; exit cleanly like the
+    // native client would.
+    appendLog(logPath, "no_executable_statements=true");
     return;
   }
 
@@ -68,13 +71,16 @@ async function main(): Promise<void> {
   appendLog(logPath, "send_logs_level=" + safeForLog(args.sendLogsLevel));
   appendLog(logPath, "max_insert_threads=" + safeForLog(args.maxInsertThreads));
   appendLog(logPath, "server_settings=" + JSON.stringify(args.serverSettings));
-  appendLog(logPath, "queries_count=" + String(queries.length));
-  for (const q of queries) {
-    appendLog(logPath, "query=" + q);
+  appendLog(logPath, "queries_count=" + String(statements.length));
+  for (const stmt of statements) {
+    appendLog(logPath, "query=" + stmt.sql);
+    if (stmt.expectedError !== null) {
+      appendLog(logPath, "expected_error=" + stmt.expectedError.label);
+    }
   }
 
   try {
-    await executeWithClient({ args, queries, logPath });
+    await executeWithClient({ args, statements, logPath });
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
     appendLog(logPath, "error=" + msg);

--- a/tests/clickhouse-test-runner/src/test-hint.ts
+++ b/tests/clickhouse-test-runner/src/test-hint.ts
@@ -1,0 +1,177 @@
+// Support for upstream `clickhouse-test` error hints.
+//
+// Many `.sql` tests in ClickHouse/ClickHouse annotate a statement that is
+// *expected to fail* with a trailing comment, e.g.:
+//
+//   SELECT throwIf(1);                 -- { serverError FUNCTION_THROW_IF_VALUE_IS_NON_ZERO }
+//   SELECT * FROM does_not_parse(;     -- { clientError SYNTAX_ERROR }
+//   SELECT 1 / 0;                      -- { serverError 153, 6 }
+//
+// The real `clickhouse-client` parses these hints (see upstream
+// `src/Client/TestHint.cpp`) and, when the query raises the expected error,
+// treats it as a pass and emits no output. Our Node shim must do the same,
+// otherwise the propagated `ClickHouseError` aborts the script and the test is
+// reported as a failure even though the server behaved exactly as expected.
+//
+// Upstream rule we mirror: an error hint is only honored when it *trails* the
+// statement it refers to — hints in a leading comment are ignored. Because our
+// statement splitter cuts on `;`, the trailing comment of statement N ends up
+// as the leading comment of statement N+1 (or as a standalone comment-only
+// final element). We therefore attach a leading hint to the *previous*
+// statement, which reproduces the upstream "trailing comment" semantics.
+
+/** A set of error codes/names a query is expected to fail with. */
+export interface ExpectedError {
+  /** Human-readable hint, e.g. `serverError SIZES_OF_ARRAYS_DONT_MATCH`. */
+  label: string;
+  /** Numeric error codes (as strings), matched against `ClickHouseError.code`. */
+  codes: Set<string>;
+  /** Named error codes, matched against `ClickHouseError.type`. */
+  names: Set<string>;
+}
+
+/** A single statement to run, with an optional expected-error annotation. */
+export interface Statement {
+  sql: string;
+  expectedError: ExpectedError | null;
+}
+
+const ERROR_COMMANDS = new Set(["serverError", "clientError", "error"]);
+
+/**
+ * Parse the contents of a single hint comment (the text *including* the comment
+ * markers). Returns the expected error if the comment carries a
+ * `serverError` / `clientError` / `error` directive, otherwise `null`.
+ *
+ * We deliberately merge `serverError` and `clientError` codes into one
+ * acceptance set: over HTTP every failure surfaces as a server error, so a
+ * `clientError` hint (which upstream attributes to the native client's local
+ * parsing) is still satisfied when the matching code comes back from the
+ * server.
+ */
+export function parseHintComment(comment: string): ExpectedError | null {
+  const open = comment.indexOf("{");
+  if (open === -1) return null;
+  const close = comment.indexOf("}", open + 1);
+  if (close === -1) return null;
+
+  const inner = comment.slice(open + 1, close);
+  const tokens = inner.split(/[\s,]+/).filter((t) => t.length > 0);
+  const cmdIndex = tokens.findIndex((t) => ERROR_COMMANDS.has(t));
+  if (cmdIndex === -1) return null;
+
+  const command = tokens[cmdIndex];
+  const codes = new Set<string>();
+  const names = new Set<string>();
+  // Everything after the command keyword is a comma-separated list of codes,
+  // each either a numeric error code or a named one (e.g. SYNTAX_ERROR).
+  for (const token of tokens.slice(cmdIndex + 1)) {
+    if (/^\d+$/.test(token)) {
+      codes.add(token);
+    } else {
+      names.add(token);
+    }
+  }
+  if (codes.size === 0 && names.size === 0) return null;
+
+  const label = `${command} ${tokens.slice(cmdIndex + 1).join(", ")}`;
+  return { label, codes, names };
+}
+
+/**
+ * Walk the leading run of whitespace and comments of a statement and return the
+ * first error hint found, or `null`. Scanning stops at the first non-comment
+ * token (where the SQL body begins), so genuine trailing hints — which live in
+ * the *next* split element — are not picked up here.
+ */
+function extractLeadingHint(statement: string): ExpectedError | null {
+  let i = 0;
+  const n = statement.length;
+  while (i < n) {
+    const ch = statement.charAt(i);
+    if (ch === " " || ch === "\t" || ch === "\n" || ch === "\r") {
+      i++;
+      continue;
+    }
+    if (ch === "-" && statement.charAt(i + 1) === "-") {
+      const newlineIdx = statement.indexOf("\n", i + 2);
+      const end = newlineIdx === -1 ? n : newlineIdx;
+      const hint = parseHintComment(statement.slice(i, end));
+      if (hint) return hint;
+      i = end;
+      continue;
+    }
+    if (ch === "/" && statement.charAt(i + 1) === "*") {
+      const closeIdx = statement.indexOf("*/", i + 2);
+      const end = closeIdx === -1 ? n : closeIdx + 2;
+      const hint = parseHintComment(statement.slice(i, end));
+      if (hint) return hint;
+      i = end;
+      continue;
+    }
+    break; // SQL body starts here
+  }
+  return null;
+}
+
+/** Whether a split element contains any SQL beyond comments/whitespace. */
+function hasSqlContent(statement: string): boolean {
+  let i = 0;
+  const n = statement.length;
+  while (i < n) {
+    const ch = statement.charAt(i);
+    if (ch === " " || ch === "\t" || ch === "\n" || ch === "\r") {
+      i++;
+      continue;
+    }
+    if (ch === "-" && statement.charAt(i + 1) === "-") {
+      const newlineIdx = statement.indexOf("\n", i + 2);
+      i = newlineIdx === -1 ? n : newlineIdx;
+      continue;
+    }
+    if (ch === "/" && statement.charAt(i + 1) === "*") {
+      const closeIdx = statement.indexOf("*/", i + 2);
+      i = closeIdx === -1 ? n : closeIdx + 2;
+      continue;
+    }
+    return true;
+  }
+  return false;
+}
+
+/**
+ * Turn the raw output of `splitQueries` into executable statements, attaching
+ * each trailing error hint to the statement it annotates. Comment-only
+ * elements (e.g. a hint left dangling after the final statement) carry their
+ * hint to the preceding statement and are otherwise dropped.
+ */
+export function buildStatements(rawQueries: string[]): Statement[] {
+  const statements: Statement[] = [];
+  for (const raw of rawQueries) {
+    const hint = extractLeadingHint(raw);
+    const previous = statements[statements.length - 1];
+    if (hint && previous !== undefined) {
+      // The trailing hint of the previous statement (upstream semantics).
+      previous.expectedError = hint;
+    }
+    // A leading hint with no preceding statement is ignored, matching upstream.
+    if (hasSqlContent(raw)) {
+      statements.push({ sql: raw, expectedError: null });
+    }
+  }
+  return statements;
+}
+
+/** Whether an error raised by the client matches the expected-error hint. */
+export function errorMatchesExpectation(
+  err: unknown,
+  expected: ExpectedError,
+): boolean {
+  if (typeof err !== "object" || err === null) return false;
+  const code = (err as { code?: unknown }).code;
+  const type = (err as { type?: unknown }).type;
+  if (typeof code === "string" && expected.codes.has(code)) return true;
+  if (typeof code === "number" && expected.codes.has(String(code))) return true;
+  if (typeof type === "string" && expected.names.has(type)) return true;
+  return false;
+}


### PR DESCRIPTION
## Summary

The `upstream-sql-tests` workflow has been failing on every nightly run (and on `main` pushes / PRs) for over a week — a single test, `03380_accurate_cast_or_null_qbit`, on one shard, failing identically on `head` and `latest`.

**Root cause:** upstream added a statement annotated with `-- { serverError SIZES_OF_ARRAYS_DONT_MATCH }` — i.e. the query is *expected to throw*. The native `clickhouse-client` parses these trailing hints (`src/Client/TestHint.cpp`) and treats a matching error as a pass; our Node shim had no such handling, so the propagated `ClickHouseError` aborted the script and `clickhouse-test` recorded a FAIL. Not a flake, not a client regression — a harness gap.

## Changes

- **`src/test-hint.ts`** (new) — parses `-- { serverError ... }` / `-- { clientError ... }` / `-- { error ... }` hints (numeric and named codes, comma lists, block comments), attaches each trailing hint to the statement it annotates (the splitter cuts on `;`, so a hint becomes the *next* element's leading comment → attached to the previous statement, matching upstream's trailing-comment semantics), and matches against `ClickHouseError.code` / `.type`.
- **`backends/client.ts`** — per statement: a matched expected error is suppressed (no output, continue); a wrong error or an unexpectedly-successful query fails. Also set `log.level = OFF` — `clickhouse-test` fails any test that writes to **stderr**, so the client's default error logger must stay quiet on suppressed errors.
- **`main.ts`** — builds `Statement[]` and threads expectations through.
- **`__tests__/test-hint.test.ts`** (new) — unit tests for parsing, hint association, and error matching.

## Verification

- Lint, typecheck, and unit tests (**53 passing**) all green.
- End-to-end against a live server: a matching serverError is suppressed → exit 0, correct stdout, **0 bytes stderr**; a mismatched code and an unexpected success both fail correctly; normal queries and genuine errors unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)