### PR TITLE
fix(rowbinary): harden writer edge cases from #911 review

### DIFF
--- a/skills/clickhouse-js-node-rowbinary-parser/CHANGELOG.md
+++ b/skills/clickhouse-js-node-rowbinary-parser/CHANGELOG.md
@@ -25,8 +25,11 @@
   for (const chunk of writeRows(writeRow)(rows, 64 * 1024)) send(chunk);
   ```
 
+  Writer edge-case hardening: `writeDate`/`writeDate32`/`writeDateTime` floor to the calendar day / whole second instead of rounding (so a non-midnight `Date` or sub-second `DateTime` no longer rounds up); `parseIPv6` rejects malformed hex groups instead of silently encoding `0`; and `writeGeometry` validates the discriminant before writing its byte, so an out-of-range value can't leave a partial payload. ([#916])
+
 [#911]: https://github.com/ClickHouse/clickhouse-js/pull/911
 [#915]: https://github.com/ClickHouse/clickhouse-js/pull/915
+[#916]: https://github.com/ClickHouse/clickhouse-js/pull/916
 
 # 0.1.2
 

--- a/skills/clickhouse-js-node-rowbinary-parser/src/datetime_writer.ts
+++ b/skills/clickhouse-js-node-rowbinary-parser/src/datetime_writer.ts
@@ -6,36 +6,42 @@ const MS_PER_DAY = 86_400_000;
 /**
  * Write a `Date`: 2-byte `UInt16` count of days since 1970-01-01 (UTC). The
  * inverse of `readDate` — the `Date` it produced is at UTC midnight, so
- * `getTime() / 86_400_000` recovers the whole-day count exactly.
+ * `getTime() / 86_400_000` recovers the whole-day count exactly. A non-midnight
+ * input is floored to its calendar day (matching ClickHouse's truncation),
+ * never rounded up into the next day.
  */
 export function writeDate(sink: Sink, value: Date): void {
   sink.view.setUint16(
     reserve(sink, 2),
-    Math.round(value.getTime() / MS_PER_DAY),
+    Math.floor(value.getTime() / MS_PER_DAY),
     true,
   );
 }
 
 /**
  * Write a `Date32`: 4-byte signed `Int32` count of days since 1970-01-01 (UTC),
- * negative for pre-1970 dates. The inverse of `readDate32`.
+ * negative for pre-1970 dates. The inverse of `readDate32`. A non-midnight input
+ * is floored toward -inf to its calendar day, so pre-1970 instants land on the
+ * correct (more negative) day rather than rounding toward the epoch.
  */
 export function writeDate32(sink: Sink, value: Date): void {
   sink.view.setInt32(
     reserve(sink, 4),
-    Math.round(value.getTime() / MS_PER_DAY),
+    Math.floor(value.getTime() / MS_PER_DAY),
     true,
   );
 }
 
 /**
  * Write a `DateTime`: 4-byte `UInt32` Unix seconds. The inverse of `readDateTime`;
- * the column timezone is metadata, not in the bytes.
+ * the column timezone is metadata, not in the bytes. Sub-second components are
+ * floored away (matching the reader and `writeDateTime64`'s `Math.floor`), never
+ * rounded up to the next second.
  */
 export function writeDateTime(sink: Sink, value: Date): void {
   sink.view.setUint32(
     reserve(sink, 4),
-    Math.round(value.getTime() / 1000),
+    Math.floor(value.getTime() / 1000),
     true,
   );
 }

--- a/skills/clickhouse-js-node-rowbinary-parser/src/datetime_writer.ts
+++ b/skills/clickhouse-js-node-rowbinary-parser/src/datetime_writer.ts
@@ -9,6 +9,12 @@ const MS_PER_DAY = 86_400_000;
  * `getTime() / 86_400_000` recovers the whole-day count exactly. A non-midnight
  * input is floored to its calendar day (matching ClickHouse's truncation),
  * never rounded up into the next day.
+ *
+ * PRECONDITION: a valid `Date` whose day count fits the `UInt16` range
+ * (1970-01-01 … ~2149-06-06). Like every leaf writer (see `writeUVarint`) this
+ * is not range-checked — an invalid or out-of-range `Date` (e.g. a pre-1970 one,
+ * which belongs in {@link writeDate32}) is a programming error; the resulting
+ * bytes are rejected server-side.
  */
 export function writeDate(sink: Sink, value: Date): void {
   sink.view.setUint16(
@@ -23,6 +29,9 @@ export function writeDate(sink: Sink, value: Date): void {
  * negative for pre-1970 dates. The inverse of `readDate32`. A non-midnight input
  * is floored toward -inf to its calendar day, so pre-1970 instants land on the
  * correct (more negative) day rather than rounding toward the epoch.
+ *
+ * PRECONDITION: a valid `Date` whose day count fits `Int32`. Not range-checked
+ * (as elsewhere) — an invalid `Date` is a programming error, rejected server-side.
  */
 export function writeDate32(sink: Sink, value: Date): void {
   sink.view.setInt32(
@@ -37,6 +46,10 @@ export function writeDate32(sink: Sink, value: Date): void {
  * the column timezone is metadata, not in the bytes. Sub-second components are
  * floored away (matching the reader and `writeDateTime64`'s `Math.floor`), never
  * rounded up to the next second.
+ *
+ * PRECONDITION: a valid `Date` whose Unix-seconds fit the `UInt32` range
+ * (1970-01-01 … 2106-02-07). Not range-checked (as elsewhere) — an invalid or
+ * out-of-range `Date` is a programming error, rejected server-side.
  */
 export function writeDateTime(sink: Sink, value: Date): void {
   sink.view.setUint32(

--- a/skills/clickhouse-js-node-rowbinary-parser/src/geo_writer.ts
+++ b/skills/clickhouse-js-node-rowbinary-parser/src/geo_writer.ts
@@ -92,20 +92,29 @@ export const writeGeometry: Writer<GeometryValue> = (sink, value) => {
     writeUInt8(sink, 0xff);
     return;
   }
+  // The discriminant byte is written inside each case, only after the switch
+  // has accepted it — an out-of-range value throws from `default` before the
+  // sink is advanced, so it never leaves a partially-written payload behind
+  // (mirrors `writeVariant`).
   const [discriminant, geo] = value;
-  writeUInt8(sink, discriminant);
   switch (discriminant) {
     case 0:
+      writeUInt8(sink, discriminant);
       return writeLineString(sink, geo as Point[]);
     case 1:
+      writeUInt8(sink, discriminant);
       return writeMultiLineString(sink, geo as Point[][]);
     case 2:
+      writeUInt8(sink, discriminant);
       return writeMultiPolygon(sink, geo as Point[][][]);
     case 3:
+      writeUInt8(sink, discriminant);
       return writePoint(sink, geo as Point);
     case 4:
+      writeUInt8(sink, discriminant);
       return writePolygon(sink, geo as Point[][]);
     case 5:
+      writeUInt8(sink, discriminant);
       return writeRing(sink, geo as Point[]);
     default:
       throw new RangeError(

--- a/skills/clickhouse-js-node-rowbinary-parser/src/ip_writer.ts
+++ b/skills/clickhouse-js-node-rowbinary-parser/src/ip_writer.ts
@@ -80,7 +80,15 @@ export function parseIPv6(text: string): Buffer {
         const v4 = parseIPv4(part);
         groups.push((v4 >>> 16) & 0xffff, v4 & 0xffff);
       } else {
-        groups.push(parseInt(part, 16) & 0xffff);
+        // 1–4 hex digits only. Parsing strictly rather than `parseInt(...) &
+        // 0xffff` rejects malformed groups instead of silently turning them
+        // into 0 (`NaN & 0xffff`) or wrapping negatives like "-1" to 0xffff.
+        if (!/^[0-9a-fA-F]{1,4}$/.test(part)) {
+          throw new RangeError(
+            `RowBinary: invalid IPv6 group ${JSON.stringify(part)}`,
+          );
+        }
+        groups.push(parseInt(part, 16));
       }
     }
     return groups;

--- a/skills/clickhouse-js-node-rowbinary-parser/tests/DateTime.write.test.ts
+++ b/skills/clickhouse-js-node-rowbinary-parser/tests/DateTime.write.test.ts
@@ -33,6 +33,28 @@ describe("writeDateTime", () => {
     ));
 });
 
+// Sub-day / sub-second inputs are floored to the encoded unit, never rounded
+// up. Asserted purely (encode-vs-encode against the truncated instant) so the
+// cases run without a live ClickHouse and can't be masked by a reader.
+describe("date/time flooring", () => {
+  it("floors a near-midnight Date down to its own calendar day", () =>
+    expect(
+      encode(writeDate, new Date(Date.UTC(2021, 6, 7, 23, 59, 59))),
+    ).toEqual(encode(writeDate, new Date(Date.UTC(2021, 6, 7)))));
+
+  it("floors a pre-1970 Date32 toward the earlier day, not the epoch", () =>
+    expect(
+      encode(writeDate32, new Date(Date.UTC(1969, 11, 31, 12, 0, 0))),
+    ).toEqual(encode(writeDate32, new Date(Date.UTC(1969, 11, 31)))));
+
+  it("floors a sub-second DateTime down, never up to the next second", () =>
+    expect(
+      encode(writeDateTime, new Date(Date.UTC(2021, 6, 7, 18, 30, 0, 600))),
+    ).toEqual(
+      encode(writeDateTime, new Date(Date.UTC(2021, 6, 7, 18, 30, 0))),
+    ));
+});
+
 describe("writeDateTime64", () => {
   const wholeSecond = new Date(Date.UTC(2021, 6, 7, 18, 30, 0));
 

--- a/skills/clickhouse-js-node-rowbinary-parser/tests/Geo.write.test.ts
+++ b/skills/clickhouse-js-node-rowbinary-parser/tests/Geo.write.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { query } from "./clickhouse.js";
 import { encode } from "./encode.js";
+import { Sink } from "../src/core_writer.js";
 import {
   writePoint,
   writeRing,
@@ -88,4 +89,12 @@ describe("writeGeometry", () => {
     ));
   it("encodes NULL as a single 0xFF byte", () =>
     expect([...encode(writeGeometry, null)]).toEqual([0xff]));
+
+  it("throws on an unknown discriminant without writing the byte", () => {
+    const sink = new Sink(Buffer.allocUnsafe(16));
+    expect(() => writeGeometry(sink, [6, [1, 2]])).toThrow(RangeError);
+    // The discriminant is validated before the byte is written, so a rejected
+    // value leaves no partial payload behind.
+    expect(sink.bytes().length).toBe(0);
+  });
 });

--- a/skills/clickhouse-js-node-rowbinary-parser/tests/IP.write.test.ts
+++ b/skills/clickhouse-js-node-rowbinary-parser/tests/IP.write.test.ts
@@ -62,3 +62,14 @@ describe("writeIPv6", () => {
       writeIPv6(new Sink(Buffer.allocUnsafe(16)), Buffer.alloc(4)),
     ).toThrow(RangeError));
 });
+
+describe("parseIPv6 validation", () => {
+  it("rejects a non-hex group instead of silently encoding 0", () =>
+    expect(() => parseIPv6("2001:db8::gggg")).toThrow(RangeError));
+  it("rejects a negative group instead of wrapping to 0xffff", () =>
+    expect(() => parseIPv6("2001:db8::-1")).toThrow(RangeError));
+  it("rejects an over-long (5-digit) group", () =>
+    expect(() => parseIPv6("2001:db8::12345")).toThrow(RangeError));
+  it("rejects an empty group", () =>
+    expect(() => parseIPv6("2001:db8:::1")).toThrow(RangeError));
+});


### PR DESCRIPTION
## Summary

Follow-up PR for the RowBinary **writer** added in #911. Peter's own review comments on #911 were all resolved during that PR; the remaining items were the Copilot bot's review findings, which Peter left for a separate PR ("Looks good so far, gonna continue in another PR"). This addresses the three that were still live in `main`:

- **`datetime_writer.ts` — round → floor.** `writeDate`, `writeDate32` and `writeDateTime` used `Math.round`, which shifts a non-midnight `Date` into the next/previous day (`12:00` → next day) and a sub-second `DateTime` up to the next second (`00:00:00.600` → `+1s`). They now `Math.floor`, truncating to the calendar day / whole second — matching `readDate*`/`readDateTime` and the existing `writeDateTime64` (`Math.floor(getTime()/1000)`). `writeDate32` floors toward `-inf`, so pre-1970 instants land on the correct earlier day rather than rounding toward the epoch.
- **`ip_writer.ts` — strict IPv6 group parsing.** `parseIPv6` did `parseInt(part, 16) & 0xffff`, which silently encoded malformed groups as `0` (`NaN & 0xffff === 0`) and wrapped negatives like `"-1"` to `0xffff`. It now validates each group is 1–4 hex digits and throws `RangeError` otherwise.
- **`geo_writer.ts` — validate before writing.** `writeGeometry` wrote the 1-byte discriminant *before* the `switch`, so an out-of-range discriminant threw *after* advancing the sink, leaving a partial payload. The discriminant byte is now written only inside an accepted `case`; an unknown value throws from `default` before any bytes are written (mirrors `writeVariant`).

Two other Copilot findings on #911 are already resolved and need no change here: the `WRITER_TODO.md` `NeedMoreSpace`/`BufferFull` mismatch (the file was removed) and the missing CHANGELOG entry (added for #911/#915). The `writeRows` design comment was handled in #915.

## Tests

Each fix gets a ClickHouse-independent test (`encode`-vs-`encode` for the flooring, throw-assertions for the validation), so they run without a live server and can't be masked by a reader. Full package suite: **724 passing**, typecheck and prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)