### PR TITLE
chore(datatype-parser): bump version to 0.1.3

### DIFF
--- a/packages/datatype-parser/package.json
+++ b/packages/datatype-parser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clickhouse/datatype-parser",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Standalone ClickHouse data-type string parser — a TypeScript port of the chdt C++ library.",
   "license": "Apache-2.0",
   "type": "module",


### PR DESCRIPTION
Bumps `@clickhouse/datatype-parser` from 0.1.2 → 0.1.3.

The `# 0.1.3` CHANGELOG section is already on `main` (Node.js 18 support drop, `engines.node` raised to `>=20`, #906). This PR only bumps `package.json` so the version can be cut.

Part of the standalone-package release flow (Part B of the `release` skill).

🤖 Generated with [Claude Code](https://claude.com/claude-code)