### PR TITLE
0.1.3 release

### DIFF
--- a/packages/datatype-parser/package.json
+++ b/packages/datatype-parser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clickhouse/datatype-parser",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Standalone ClickHouse data-type string parser — a TypeScript port of the chdt C++ library.",
   "license": "Apache-2.0",
   "type": "module",


### PR DESCRIPTION
Sync `release` from `main` to cut `@clickhouse/datatype-parser` 0.1.3.

Contains the version bump (#924). The `# 0.1.3` CHANGELOG section (Node.js 18 support drop, `engines.node` → `>=20`, #906) is already on `release` from a prior sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)