### PR TITLE
1.23.0 release

### DIFF
--- a/.github/workflows/publish-client-common.yml
+++ b/.github/workflows/publish-client-common.yml
@@ -53,42 +53,6 @@ env:
   NPM_CONFIG_FETCH_TIMEOUT: "600000"
 
 jobs:
-  head:
-    name: "Publish @clickhouse/client-common (head)"
-    if: github.ref == 'refs/heads/release' && github.event_name == 'push'
-    runs-on: ubuntu-latest
-    environment: npm-publish
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-
-      - name: Setup Node.js
-        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
-        with:
-          node-version: 24
-          registry-url: "https://registry.npmjs.org"
-
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Set head pre-release version
-        run: |
-          BASE_VERSION=$(node -p "require('./packages/client-common/package.json').version")
-          HEAD_VERSION="${BASE_VERSION}-head.${GITHUB_SHA::7}.${GITHUB_RUN_ATTEMPT}"
-          echo "Setting version to: $HEAD_VERSION"
-          npm --workspace @clickhouse/client-common version --no-git-tag-version "$HEAD_VERSION"
-          echo "export default \"$HEAD_VERSION\";" > packages/client-common/src/version.ts
-
-      - name: Build the package
-        run: npm --workspace @clickhouse/client-common run build
-
-      - name: Publish @clickhouse/client-common with head tag
-        run: |
-          npm --workspace @clickhouse/client-common publish \
-            --access public \
-            --provenance \
-            --tag head
-
   publish:
     name: "Publish @clickhouse/client-common (deprecated)"
     if: github.ref == 'refs/heads/release' && github.event_name == 'workflow_dispatch'

--- a/package-lock.json
+++ b/package-lock.json
@@ -348,16 +348,8 @@
       "link": true
     },
     "node_modules/@clickhouse/rowbinary": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/@clickhouse/rowbinary/-/rowbinary-0.1.2.tgz",
-      "integrity": "sha512-BHc8DXdK+ORxQe5BhPC9bJbOk0zmJlXvdC7rhiMGFcECT+QyZLgAo4aQuwpRW7Ms90/ufict28JBmiON+rUcjw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@clickhouse/datatype-parser": "^0.1.2"
-      },
-      "engines": {
-        "node": ">=20"
-      }
+      "resolved": "skills/clickhouse-js-node-rowbinary",
+      "link": true
     },
     "node_modules/@emnapi/core": {
       "version": "1.10.0",
@@ -7757,12 +7749,28 @@
         "node": ">=14.17"
       }
     },
+    "skills/clickhouse-js-node-rowbinary": {
+      "name": "@clickhouse/rowbinary",
+      "version": "0.2.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@clickhouse/datatype-parser": "^0.1.2"
+      },
+      "devDependencies": {
+        "@types/node": "25.9.3",
+        "typescript": "^6.0.3",
+        "vitest": "^4.1.9"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "tests/clickhouse-test-runner": {
       "name": "@clickhouse/clickhouse-test-runner",
       "version": "1.23.0",
       "dependencies": {
         "@clickhouse/client": "*",
-        "@clickhouse/rowbinary": "^0.1.2"
+        "@clickhouse/rowbinary": "file:../../skills/clickhouse-js-node-rowbinary"
       },
       "bin": {
         "clickhouse-js-test-runner": "dist/main.js"

--- a/skills/clickhouse-js-node-rowbinary/package-lock.json
+++ b/skills/clickhouse-js-node-rowbinary/package-lock.json
@@ -12,7 +12,7 @@
         "@clickhouse/datatype-parser": "^0.1.2"
       },
       "devDependencies": {
-        "@types/node": "^26.0.0",
+        "@types/node": "25.9.3",
         "typescript": "^6.0.3",
         "vitest": "^4.1.9"
       },
@@ -425,13 +425,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "26.0.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.0.0.tgz",
-      "integrity": "sha512-vf2YFi1iY9lHGwNJMs01biZFbKJkrZR1T6/MlzjhJLPdntOHLhTrDSnSVcdtvjihi4VQNlrFRIxLsDBlQpAipA==",
+      "version": "25.9.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.3.tgz",
+      "integrity": "sha512-603BddQMv3pUcr4U2dhujk83N2tTDVr/34wII2B6bJy6g+8WD6yUb11jszNs0gdi4PesVWl7ABt8nYMVpnLUcg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~8.3.0"
+        "undici-types": ">=7.24.0 <7.24.7"
       }
     },
     "node_modules/@vitest/expect": {
@@ -1148,9 +1148,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
-      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
+      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
       "dev": true,
       "license": "MIT"
     },

--- a/skills/clickhouse-js-node-rowbinary/package.json
+++ b/skills/clickhouse-js-node-rowbinary/package.json
@@ -74,7 +74,7 @@
     "@clickhouse/datatype-parser": "^0.1.2"
   },
   "devDependencies": {
-    "@types/node": "^26.0.0",
+    "@types/node": "25.9.3",
     "typescript": "^6.0.3",
     "vitest": "^4.1.9"
   }

--- a/tests/clickhouse-test-runner/__tests__/tsv-serialize.test.ts
+++ b/tests/clickhouse-test-runner/__tests__/tsv-serialize.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { parseDataType } from "@clickhouse/datatype-parser";
-import { formatUUID } from "@clickhouse/rowbinary/uuid";
+import { formatUUID } from "@clickhouse/rowbinary/readers/uuid";
 import { renderValue, compileRowRenderers } from "../src/tsv-serialize.js";
 
 /**
@@ -100,9 +100,13 @@ describe("renderValue — top level (escaped, unquoted)", () => {
     expect(render("IPv6", ipv6)).toBe("::1");
   });
 
-  it("enum maps the wire integer to its name", () => {
-    expect(render("Enum8('x' = 1, 'y' = 2)", 2)).toBe("y");
-    expect(render("Enum16('a' = 10, 'b' = -20)", -20)).toBe("b");
+  it("renders the enum name the reader already resolved", () => {
+    // @clickhouse/rowbinary resolves Enum8/16 to the NAME (not the wire
+    // integer), so renderValue receives the name string and renders it
+    // stringish: escaped + unquoted at top level, single-quoted when nested.
+    expect(render("Enum8('x' = 1, 'y' = 2)", "y")).toBe("y");
+    expect(render("Enum16('a' = 10, 'b' = -20)", "b")).toBe("b");
+    expect(render("Enum8('x' = 1, 'y' = 2)", "y", true)).toBe("'y'");
   });
 
   it("NULL is backslash-N at top level", () => {

--- a/tests/clickhouse-test-runner/package.json
+++ b/tests/clickhouse-test-runner/package.json
@@ -12,7 +12,9 @@
   },
   "scripts": {
     "pack": "true",
-    "build": "rm -rf dist && tsc -p tsconfig.build.json && chmod +x dist/main.js",
+    "build": "npm run build:rowbinary && rm -rf dist && tsc -p tsconfig.build.json && chmod +x dist/main.js",
+    "//build:rowbinary": "The in-repo @clickhouse/rowbinary skill is linked via file: (not a workspace, so it stays out of the root install/lint/test sweeps and keeps its own standalone CI). Its dist is gitignored, so build it here — the test runner is the last workspace built, so packages/* (datatype-parser) are already compiled when the skill's tsc resolves them.",
+    "build:rowbinary": "tsc -p ../../skills/clickhouse-js-node-rowbinary/tsconfig.build.json",
     "typecheck": "tsc --noEmit",
     "lint": "eslint --max-warnings=0 .",
     "lint:fix": "eslint . --fix",
@@ -20,7 +22,7 @@
   },
   "dependencies": {
     "@clickhouse/client": "*",
-    "@clickhouse/rowbinary": "^0.1.2"
+    "@clickhouse/rowbinary": "file:../../skills/clickhouse-js-node-rowbinary"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",

--- a/tests/clickhouse-test-runner/src/backends/rowbinary.ts
+++ b/tests/clickhouse-test-runner/src/backends/rowbinary.ts
@@ -1,5 +1,5 @@
-import { compileRowBinaryWithNamesAndTypes } from "@clickhouse/rowbinary/rowBinaryWithNamesAndTypes";
-import { Cursor } from "@clickhouse/rowbinary/core";
+import { compileRowBinaryWithNamesAndTypes } from "@clickhouse/rowbinary/readers/rowBinaryWithNamesAndTypes";
+import { Cursor } from "@clickhouse/rowbinary/readers/core";
 import { compileRowRenderers } from "../tsv-serialize.js";
 import { appendLog } from "../log.js";
 import {

--- a/tests/clickhouse-test-runner/src/tsv-serialize.ts
+++ b/tests/clickhouse-test-runner/src/tsv-serialize.ts
@@ -13,8 +13,9 @@
  * The renderer is TYPE-DIRECTED: it walks the column's parsed data-type AST
  * (from `@clickhouse/datatype-parser`, the same AST the parser folds into
  * readers) alongside the decoded value, because the JS value alone is
- * insufficient to reproduce ClickHouse's text — e.g. an `Enum8` decodes to its
- * underlying integer but TSV prints the NAME, which lives only in the type.
+ * insufficient to reproduce ClickHouse's text — e.g. a `DateTime64(P)` decodes
+ * to `[Date, nanoseconds]` but the sub-second precision `P` that decides how
+ * many fractional digits to print lives only in the type.
  *
  * Two text contexts, mirroring ClickHouse's `serializeTextEscaped` (top level)
  * vs `serializeTextQuoted` (inside Array/Tuple/Map):
@@ -33,10 +34,10 @@ import {
   NodeKind,
   type Node,
 } from "@clickhouse/datatype-parser";
-import { formatDecimal } from "@clickhouse/rowbinary/decimals";
-import { formatTime, formatTime64 } from "@clickhouse/rowbinary/time";
-import { formatUUID } from "@clickhouse/rowbinary/uuid";
-import { formatIPv4, formatIPv6 } from "@clickhouse/rowbinary/ip";
+import { formatDecimal } from "@clickhouse/rowbinary/readers/decimals";
+import { formatTime, formatTime64 } from "@clickhouse/rowbinary/readers/time";
+import { formatUUID } from "@clickhouse/rowbinary/readers/uuid";
+import { formatIPv4, formatIPv6 } from "@clickhouse/rowbinary/readers/ip";
 
 /** Thrown when a column type has no TSV renderer yet (see module note). */
 export class TSVRenderError extends Error {
@@ -161,17 +162,6 @@ function renderPointArray(
   return `[${(value as unknown[]).map(renderElem).join(",")}]`;
 }
 
-/** Map a decoded enum integer to its name via the explicit `'name' = value` pairs in the type. */
-function enumName(node: Node, value: unknown): string {
-  const v = BigInt(value as number);
-  for (const ev of node.values) {
-    if (ev.value === v) return ev.name;
-  }
-  throw new TSVRenderError(
-    `enum value ${String(value)} not found in ${node.name}`,
-  );
-}
-
 function requireArg(node: Node, index: number): Node {
   const arg = node.arguments[index];
   if (arg === undefined) {
@@ -201,7 +191,10 @@ export function renderValue(
   if (value === null || value === undefined) return nested ? "NULL" : "\\N";
 
   if (node.kind === NodeKind.EnumDataType) {
-    return renderStringish(enumName(node, value), nested);
+    // @clickhouse/rowbinary's enum readers already resolve the underlying
+    // integer to its NAME via the type's value→name map, so render that string
+    // directly (ClickHouse TSV prints the enum name, not the integer).
+    return renderStringish(String(value), nested);
   }
   if (node.kind === NodeKind.TupleDataType) {
     return renderTuple(node, value);


### PR DESCRIPTION
Sync `release` from `main` to cut `@clickhouse/client` 1.23.0.

Brings `release` up to `main` (currently 2 commits behind: #928, #923). Version is already bumped to 1.23.0 on `main`; `packages/client-node/CHANGELOG.md` has the `# 1.23.0` section ready.

Merging this triggers the path-scoped `head` publish + e2e for `@clickhouse/client` (the synced commits touch `package-lock.json` and `skills/**`). After head e2e is green, `latest` is published via manual `publish-client.yml` dispatch.