### PR TITLE
test(node): resolve test resources relative to repo root, drop chdir

### DIFF
--- a/packages/client-node/__tests__/integration/node_streaming_e2e.test.ts
+++ b/packages/client-node/__tests__/integration/node_streaming_e2e.test.ts
@@ -8,6 +8,7 @@ import { createSimpleTable } from "@test/fixtures/simple_table";
 import { createTestClient } from "@test/utils/client";
 import { guid } from "@test/utils/guid";
 import { genLargeStringsDataset } from "@test/utils/datasets";
+import { projectPath } from "../utils/paths";
 import { tableFromIPC } from "apache-arrow";
 import { Buffer } from "buffer";
 import Fs from "fs";
@@ -39,8 +40,9 @@ describe("[Node.js] streaming e2e", () => {
 
   it("should stream an NDJSON file", async () => {
     // contains id as numbers in JSONCompactEachRow format ["0"]\n["1"]\n...
-    const filename =
-      "packages/client-common/__tests__/fixtures/streaming_e2e_data.ndjson";
+    const filename = projectPath(
+      "packages/client-common/__tests__/fixtures/streaming_e2e_data.ndjson",
+    );
     await client.insert({
       table: tableName,
       values: Fs.createReadStream(filename).pipe(
@@ -74,8 +76,9 @@ describe("[Node.js] streaming e2e", () => {
       output_format_parquet_string_as_string: 1,
     };
 
-    const filename =
-      "packages/client-common/__tests__/fixtures/streaming_e2e_data.parquet";
+    const filename = projectPath(
+      "packages/client-common/__tests__/fixtures/streaming_e2e_data.parquet",
+    );
     await client.insert({
       table: tableName,
       values: Fs.createReadStream(filename),

--- a/packages/client-node/__tests__/tls/tls.test.ts
+++ b/packages/client-node/__tests__/tls/tls.test.ts
@@ -9,6 +9,7 @@ import { createClient } from "../../src";
 import Https from "https";
 import http from "http";
 import { vi } from "vitest";
+import { projectPath } from "../utils/paths";
 
 describe("[Node.js] TLS connection", () => {
   let client: ClickHouseClient<Stream.Readable>;
@@ -19,7 +20,9 @@ describe("[Node.js] TLS connection", () => {
     await client.close();
   });
 
-  const certsPath = ".docker/clickhouse/single_node_tls/certificates";
+  const certsPath = projectPath(
+    ".docker/clickhouse/single_node_tls/certificates",
+  );
   const ca_cert = fs.readFileSync(`${certsPath}/ca.crt`);
   const cert = fs.readFileSync(`${certsPath}/client.crt`);
   const key = fs.readFileSync(`${certsPath}/client.key`);

--- a/packages/client-node/__tests__/utils/paths.ts
+++ b/packages/client-node/__tests__/utils/paths.ts
@@ -1,0 +1,14 @@
+import { fileURLToPath } from "node:url";
+import Path from "node:path";
+
+// Absolute path to the repository root, derived from this file's location.
+// Test resources (common fixtures, TLS certificates) are resolved through this
+// so they do not depend on the process working directory: the node package test
+// scripts run vitest via `npm --prefix packages/client-node`, which sets cwd to
+// the package dir, so cwd-relative paths would not resolve.
+const projectRootPath = fileURLToPath(new URL("../../../..", import.meta.url));
+
+// Joins repo-root-relative segments into an absolute path.
+export function projectPath(...segments: string[]): string {
+  return Path.join(projectRootPath, ...segments);
+}

--- a/packages/client-node/vitest.config.ts
+++ b/packages/client-node/vitest.config.ts
@@ -6,12 +6,6 @@ import { fileURLToPath } from "node:url";
 // common tests so the common code is exercised and shows up in coverage.
 const root = fileURLToPath(new URL("../..", import.meta.url));
 
-// The package scripts run vitest via `npm --prefix packages/client-node`, which
-// sets the process cwd to the package dir. Some specs read fixtures/certs via
-// repo-root-relative paths (e.g. node_streaming_e2e, tls), so pin the cwd to the
-// repo root to match `root` above. Workers inherit this cwd when they spawn.
-process.chdir(root);
-
 const testMode = process.env.TEST_MODE;
 if (
   testMode !== "unit" &&


### PR DESCRIPTION
## Summary

Follow-up to #931. The node package test scripts run vitest via `npm --prefix packages/client-node`, so the process cwd is the **package dir**. #931 worked around the cwd-dependent test resources by calling `process.chdir(root)` in `packages/client-node/vitest.config.ts`.

This makes the node test setup self-contained instead: cwd-dependent resources are resolved through a small `projectPath` helper anchored at the repo root via `import.meta.url`, so resolution no longer depends on the working directory — and the `chdir` is removed.

- **New** `packages/client-node/__tests__/utils/paths.ts` — `projectPath(...segments)` joins repo-root-relative segments into an absolute path, with the root derived from `import.meta.url`.
- **`node_streaming_e2e.test.ts`** — wraps the two `streaming_e2e_data.*` fixture paths in `projectPath(...)`.
- **`tls.test.ts`** — wraps the `.docker/.../certificates` path in `projectPath(...)`.
- **`vitest.config.ts`** — drops `process.chdir(root)`. The remaining config-level paths (`setupFiles`, `sdkPath`, coverage globs, `alias`, `include`) already resolve against the config `root`, not cwd, so they are unaffected.

Web is unchanged: its specs have no cwd-relative filesystem reads (the config resolves everything against `root`).

## Verification

- Confirmed all five resources (2 fixtures + 3 certs) resolve to absolute, existing paths while cwd is the package dir (chdir removed).
- `test:unit` (43 files), `typecheck`, `lint` all pass for the node package.

## Checklist

- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials