### PR TITLE
fix(client): re-export EXCEPTION_TAG_HEADER_NAME and extractErrorAtTheEndOfChunk

### DIFF
--- a/packages/client-node/CHANGELOG.md
+++ b/packages/client-node/CHANGELOG.md
@@ -1,3 +1,11 @@
+# 1.23.1
+
+## Bug Fixes
+
+- Re-export `EXCEPTION_TAG_HEADER_NAME` and `extractErrorAtTheEndOfChunk` from `@clickhouse/client`. Both are part of the (now deprecated) `@clickhouse/client-common` public API but were missed when its surface was bundled into and re-exported from the client packages in 1.23.0 ([#845]). Reported downstream by Langfuse. ([#935])
+
+[#935]: https://github.com/ClickHouse/clickhouse-js/pull/935
+
 # 1.23.0
 
 ## Migration Notes

--- a/packages/client-node/src/index.ts
+++ b/packages/client-node/src/index.ts
@@ -93,6 +93,8 @@ import {
   ClickHouseSpanStatusCode as ClickHouseSpanStatusCode_,
   ClickHouseSpanKind as ClickHouseSpanKind_,
   defaultJSONHandling as defaultJSONHandling_,
+  EXCEPTION_TAG_HEADER_NAME as EXCEPTION_TAG_HEADER_NAME_,
+  extractErrorAtTheEndOfChunk as extractErrorAtTheEndOfChunk_,
 } from "./common/index";
 
 export const ClickHouseError = ClickHouseError_;
@@ -121,3 +123,5 @@ export const ClickHouseSpanNames = ClickHouseSpanNames_;
 export const ClickHouseSpanStatusCode = ClickHouseSpanStatusCode_;
 export const ClickHouseSpanKind = ClickHouseSpanKind_;
 export const defaultJSONHandling = defaultJSONHandling_;
+export const EXCEPTION_TAG_HEADER_NAME = EXCEPTION_TAG_HEADER_NAME_;
+export const extractErrorAtTheEndOfChunk = extractErrorAtTheEndOfChunk_;

--- a/packages/client-web/CHANGELOG.md
+++ b/packages/client-web/CHANGELOG.md
@@ -1,3 +1,11 @@
+# 1.23.1
+
+## Bug Fixes
+
+- Re-export `EXCEPTION_TAG_HEADER_NAME` and `extractErrorAtTheEndOfChunk` from `@clickhouse/client-web`. Both are part of the (now deprecated) `@clickhouse/client-common` public API but were missed when its surface was bundled into and re-exported from the client packages in 1.23.0 ([#845]). Reported downstream by Langfuse. ([#935])
+
+[#935]: https://github.com/ClickHouse/clickhouse-js/pull/935
+
 # 1.23.0
 
 ## Migration Notes

--- a/packages/client-web/src/index.ts
+++ b/packages/client-web/src/index.ts
@@ -92,6 +92,8 @@ import {
   ClickHouseSpanStatusCode as ClickHouseSpanStatusCode_,
   ClickHouseSpanKind as ClickHouseSpanKind_,
   defaultJSONHandling as defaultJSONHandling_,
+  EXCEPTION_TAG_HEADER_NAME as EXCEPTION_TAG_HEADER_NAME_,
+  extractErrorAtTheEndOfChunk as extractErrorAtTheEndOfChunk_,
 } from "./common/index";
 
 export const ClickHouseError = ClickHouseError_;
@@ -120,3 +122,5 @@ export const ClickHouseSpanNames = ClickHouseSpanNames_;
 export const ClickHouseSpanStatusCode = ClickHouseSpanStatusCode_;
 export const ClickHouseSpanKind = ClickHouseSpanKind_;
 export const defaultJSONHandling = defaultJSONHandling_;
+export const EXCEPTION_TAG_HEADER_NAME = EXCEPTION_TAG_HEADER_NAME_;
+export const extractErrorAtTheEndOfChunk = extractErrorAtTheEndOfChunk_;


### PR DESCRIPTION
## Summary

The 1.23.0 migration ([#845]) deprecated `@clickhouse/client-common` and bundled its shared code into `@clickhouse/client` (Node.js) and `@clickhouse/client-web` (Web), re-exporting the public surface from each so users could switch their imports over.

Two runtime values that are part of `@clickhouse/client-common`'s public index were missed:

- `EXCEPTION_TAG_HEADER_NAME`
- `extractErrorAtTheEndOfChunk`

Downstream users import these directly. This was the first "missing re-export" report, from Langfuse: https://github.com/langfuse/langfuse/pull/14686

## Changes

Re-export both symbols from `@clickhouse/client` and `@clickhouse/client-web` using the same local-binding pattern as the other runtime values in `src/index.ts`. (Neither carries an `@deprecated` tag in the common index, so consumers importing them from the client packages get the clean, recommended path.)

## Verification

- `npm run typecheck` (node + web) — clean
- `npm run lint` (node + web) — clean
- Built the node package and confirmed both symbols resolve at runtime:
  - `EXCEPTION_TAG_HEADER_NAME === "x-clickhouse-exception-tag"`
  - `typeof extractErrorAtTheEndOfChunk === "function"`

[#845]: https://github.com/ClickHouse/clickhouse-js/pull/845

🤖 Generated with [Claude Code](https://claude.com/claude-code)