### PR TITLE
1.23.1 release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7719,7 +7719,7 @@
     },
     "packages/client-web": {
       "name": "@clickhouse/client-web",
-      "version": "1.23.0",
+      "version": "1.23.1",
       "license": "Apache-2.0"
     },
     "packages/datatype-parser": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -7708,7 +7708,7 @@
     },
     "packages/client-node": {
       "name": "@clickhouse/client",
-      "version": "1.23.0",
+      "version": "1.23.1",
       "license": "Apache-2.0",
       "devDependencies": {
         "simdjson": "^0.9.2"
@@ -7724,7 +7724,7 @@
     },
     "packages/datatype-parser": {
       "name": "@clickhouse/datatype-parser",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "license": "Apache-2.0",
       "devDependencies": {
         "tsx": "^4.22.4",

--- a/packages/client-node/package.json
+++ b/packages/client-node/package.json
@@ -2,7 +2,7 @@
   "name": "@clickhouse/client",
   "description": "Official JS client for ClickHouse DB - Node.js implementation",
   "homepage": "https://clickhouse.com",
-  "version": "1.23.0",
+  "version": "1.23.1",
   "license": "Apache-2.0",
   "keywords": [
     "clickhouse",

--- a/packages/client-node/src/version.ts
+++ b/packages/client-node/src/version.ts
@@ -1,1 +1,1 @@
-export default "1.23.0";
+export default "1.23.1";

--- a/packages/client-web/package.json
+++ b/packages/client-web/package.json
@@ -2,7 +2,7 @@
   "name": "@clickhouse/client-web",
   "description": "Official JS client for ClickHouse DB - Web API implementation",
   "homepage": "https://clickhouse.com",
-  "version": "1.23.0",
+  "version": "1.23.1",
   "license": "Apache-2.0",
   "keywords": [
     "clickhouse",

--- a/packages/client-web/src/version.ts
+++ b/packages/client-web/src/version.ts
@@ -1,1 +1,1 @@
-export default "1.23.0";
+export default "1.23.1";

--- a/scripts/ci/lockfile-age-audit.mjs
+++ b/scripts/ci/lockfile-age-audit.mjs
@@ -191,9 +191,7 @@ async function checkOne({ name, version }) {
   const url = `https://registry.npmjs.org/${encodeURIComponent(name)}`;
   let res;
   try {
-    res = await fetch(url, {
-      headers: { Accept: "application/vnd.npm.install-v1+json" },
-    });
+    res = await fetch(url);
   } catch (err) {
     errors.push(`${name}: fetch failed (${err.message})`);
     return;


### PR DESCRIPTION
Sync release from main to cut @clickhouse/client and @clickhouse/client-web 1.23.1 (patch).

Contains:
- Bump @clickhouse/client to 1.23.1 (#939)
- Bump @clickhouse/client-web to 1.23.1 (#940)
- fix(ci): lockfile-age-audit full packument (#888)

Release notes: re-export `EXCEPTION_TAG_HEADER_NAME` and `extractErrorAtTheEndOfChunk` from both client packages (#935), a public-API gap from the 1.23.0 common-bundling change, reported downstream by Langfuse.