### PR TITLE
Fix parsing of named Tuple elements

### DIFF
--- a/packages/client-common/__tests__/unit/parse_column_types_tuple.test.ts
+++ b/packages/client-common/__tests__/unit/parse_column_types_tuple.test.ts
@@ -44,6 +44,40 @@ describe("Columns types parser - Tuple", () => {
     });
   });
 
+  it("should parse Tuple with named elements", async () => {
+    const args: TestArgs[] = [
+      {
+        sourceType: "Tuple(s String, i Int64)",
+        expected: {
+          type: "Tuple",
+          elements: [
+            { type: "Simple", columnType: "String", sourceType: "String" },
+            { type: "Simple", columnType: "Int64", sourceType: "Int64" },
+          ],
+          sourceType: "Tuple(s String, i Int64)",
+        },
+      },
+      {
+        sourceType: 'Tuple(`display name` String, "item count" UInt64)',
+        expected: {
+          type: "Tuple",
+          elements: [
+            { type: "Simple", columnType: "String", sourceType: "String" },
+            { type: "Simple", columnType: "UInt64", sourceType: "UInt64" },
+          ],
+          sourceType: 'Tuple(`display name` String, "item count" UInt64)',
+        },
+      },
+    ];
+    args.forEach(({ expected, sourceType }) => {
+      const result = parseTupleType({ columnType: sourceType, sourceType });
+      expect(
+        result,
+        `Expected ${sourceType} to have ${joinElements(expected)} elements`,
+      ).toEqual(expected);
+    });
+  });
+
   it("should parse Tuple with Decimals", async () => {
     const args: TestArgs[] = [
       {

--- a/packages/client-common/src/parse/column_types.ts
+++ b/packages/client-common/src/parse/column_types.ts
@@ -542,13 +542,36 @@ export function parseTupleType({
   }
   columnType = columnType.slice(TuplePrefix.length, -1);
   const elements = getElementsTypes({ columnType, sourceType }, 1).map((type) =>
-    parseColumnType(type),
+    parseTupleElementType(type),
   );
   return {
     type: "Tuple",
     elements,
     sourceType,
   };
+}
+
+function parseTupleElementType(sourceType: string): ParsedColumnType {
+  try {
+    return parseColumnType(sourceType);
+  } catch (originalError) {
+    if (!(originalError instanceof ColumnTypeParseError)) {
+      throw originalError;
+    }
+    const namedElementType = NamedTupleElementPattern.exec(sourceType)?.[1];
+    if (namedElementType === undefined) {
+      throw originalError;
+    }
+
+    try {
+      return parseColumnType(namedElementType);
+    } catch (namedElementError) {
+      if (!(namedElementError instanceof ColumnTypeParseError)) {
+        throw namedElementError;
+      }
+      throw originalError;
+    }
+  }
 }
 
 export function parseArrayType({
@@ -795,6 +818,9 @@ const DateTimePrefix = "DateTime" as const;
 const DateTimeWithTimezonePrefix = "DateTime(" as const;
 const DateTime64Prefix = "DateTime64(" as const;
 const FixedStringPrefix = "FixedString(" as const;
+// Tuple element names may be bare or quoted with backticks/double quotes.
+const NamedTupleElementPattern =
+  /^(?:`(?:\\.|``|[^`])*`|"(?:\\.|""|[^"])*"|\S+)\s+(.+)$/;
 
 const SingleQuoteASCII = 39 as const;
 const LeftParenASCII = 40 as const;

--- a/packages/client-common/src/parse/column_types.ts
+++ b/packages/client-common/src/parse/column_types.ts
@@ -551,14 +551,15 @@ export function parseTupleType({
   };
 }
 
-function parseTupleElementType(sourceType: string): ParsedColumnType {
+function parseTupleElementType(elementSourceType: string): ParsedColumnType {
   try {
-    return parseColumnType(sourceType);
+    return parseColumnType(elementSourceType);
   } catch (originalError) {
     if (!(originalError instanceof ColumnTypeParseError)) {
       throw originalError;
     }
-    const namedElementType = NamedTupleElementPattern.exec(sourceType)?.[1];
+    const namedElementType =
+      NamedTupleElementPattern.exec(elementSourceType)?.[1];
     if (namedElementType === undefined) {
       throw originalError;
     }

--- a/packages/client-node/CHANGELOG.md
+++ b/packages/client-node/CHANGELOG.md
@@ -15,8 +15,10 @@
 ## Bug fixes
 
 - Fixed `Array(Date)` / `Array(Date32)` query-parameter binding (and other temporal element types nested in arrays, tuples, and maps). A JS `Date` inside a container was serialized as a bare Unix timestamp (e.g. `[1683244800]`), which the server's `Array(Date)` element parser rejects (`CANNOT_PARSE_INPUT_ASSERTION_FAILED`). Container-nested `Date` values are now emitted as a quoted UTC date string (e.g. `['2023-05-05']`), the one encoding every temporal element type accepts. Note: a `Date` used inside `Array(DateTime)` / `Array(DateTime64)` is now bound at day precision (the time-of-day is dropped), since date-only is the only form `Array(Date)` accepts; scalar `Date` / `DateTime` binding is unchanged. ([#947])
+- Fixed the deprecated `parseColumnType` function to parse named Tuple elements (for example, `Tuple(name String, count UInt64)`) instead of throwing `Unsupported column type`. Element names remain omitted from the legacy `ParsedColumnTuple` output; use `@clickhouse/datatype-parser` when names are needed. ([#964])
 
 [#947]: https://github.com/ClickHouse/clickhouse-js/pull/947
+[#964]: https://github.com/ClickHouse/clickhouse-js/pull/964
 
 # 1.23.1
 

--- a/packages/client-web/CHANGELOG.md
+++ b/packages/client-web/CHANGELOG.md
@@ -15,8 +15,10 @@
 ## Bug fixes
 
 - Fixed `Array(Date)` / `Array(Date32)` query-parameter binding (and other temporal element types nested in arrays, tuples, and maps). A JS `Date` inside a container was serialized as a bare Unix timestamp (e.g. `[1683244800]`), which the server's `Array(Date)` element parser rejects (`CANNOT_PARSE_INPUT_ASSERTION_FAILED`). Container-nested `Date` values are now emitted as a quoted UTC date string (e.g. `['2023-05-05']`), the one encoding every temporal element type accepts. Note: a `Date` used inside `Array(DateTime)` / `Array(DateTime64)` is now bound at day precision (the time-of-day is dropped), since date-only is the only form `Array(Date)` accepts; scalar `Date` / `DateTime` binding is unchanged. ([#947])
+- Fixed the deprecated `parseColumnType` function to parse named Tuple elements (for example, `Tuple(name String, count UInt64)`) instead of throwing `Unsupported column type`. Element names remain omitted from the legacy `ParsedColumnTuple` output; use `@clickhouse/datatype-parser` when names are needed. ([#964])
 
 [#947]: https://github.com/ClickHouse/clickhouse-js/pull/947
+[#964]: https://github.com/ClickHouse/clickhouse-js/pull/964
 
 # 1.23.1
 


### PR DESCRIPTION
## Summary

Fixes #891 by accepting optional bare or quoted element names in the deprecated tuple column-type parser while preserving its existing `ParsedColumnTuple` output shape.

## Checklist

- [x] Unit tests covering the common scenarios were added
- [x] A human-readable changelog entry was added to every affected package's `CHANGELOG.md`

## Testing

- `npm exec -- vitest run <all parse_column_types unit files>` (39 tests)
- `npm --prefix packages/client-common run typecheck`
- `npm --prefix packages/client-common run lint`
- official Node unit config (403 passed, 10 skipped)
- client-common, client-node, client-web, and datatype-parser workspace typechecks