### PR TITLE
Fix percent-encoded database names in connection URL paths

### DIFF
--- a/packages/client-common/__tests__/unit/config.test.ts
+++ b/packages/client-common/__tests__/unit/config.test.ts
@@ -8,6 +8,7 @@ import {
   getConnectionParams,
   LogWriter,
   numberConfigURLValue,
+  toSearchParams,
 } from "../../src/index";
 import { TestLogger } from "../utils/test_logger";
 import type { BaseClickHouseClientConfigOptionsWithURL } from "../../src/config";
@@ -31,6 +32,16 @@ describe("config", () => {
     it("should get all defaults with no extra configuration", async () => {
       const res = prepareConfigWithURL({}, logger, null);
       expect(res).toEqual(defaultConfig);
+    });
+
+    it("should preserve percent sequences in the database option", () => {
+      const config = prepareConfigWithURL(
+        { database: "my%20database" },
+        logger,
+        null,
+      );
+
+      expect(config.database).toBe("my%20database");
     });
 
     it("should fall back to default HTTP/HTTPS port numbers", async () => {
@@ -970,6 +981,32 @@ describe("config", () => {
         database: "analytics",
       });
     });
+
+    it.each([
+      ["spaces", "my%20database", "my database", "my+database"],
+      ["Unicode characters", "分析", "分析", "%E5%88%86%E6%9E%90"],
+      [
+        "literal percent signs",
+        "my%2520database",
+        "my%20database",
+        "my%2520database",
+      ],
+    ])(
+      "should decode %s in database names from URL paths",
+      (_characters, path, database, encodedDatabase) => {
+        const url = new URL(`http://localhost:8124/${path}`);
+        const [, config] = loadConfigOptionsFromURL(url, null);
+        const searchParams = toSearchParams({
+          database: config.database,
+          query_id: "query-id",
+        });
+
+        expect(config.database).toBe(database);
+        expect(searchParams.toString().split("&")).toContain(
+          `database=${encodedDatabase}`,
+        );
+      },
+    );
 
     it("should load only the settings from the URL, without auth", async () => {
       const url = new URL(

--- a/packages/client-common/src/config.ts
+++ b/packages/client-common/src/config.ts
@@ -498,7 +498,7 @@ export function loadConfigOptionsFromURL(
     config.password = decodeURIComponent(url.password);
   }
   if (url.pathname.trim().length > 1) {
-    config.database = url.pathname.slice(1);
+    config.database = decodeURIComponent(url.pathname.slice(1));
   }
   const urlSearchParamsKeys = [...url.searchParams.keys()];
   if (urlSearchParamsKeys.length > 0) {

--- a/packages/client-node/CHANGELOG.md
+++ b/packages/client-node/CHANGELOG.md
@@ -14,9 +14,12 @@
 
 ## Bug fixes
 
+- Fixed database names from URL paths being percent-encoded twice when they contain spaces, Unicode characters, or literal percent signs. ([#977])
+
 - Fixed `Array(Date)` / `Array(Date32)` query-parameter binding (and other temporal element types nested in arrays, tuples, and maps). A JS `Date` inside a container was serialized as a bare Unix timestamp (e.g. `[1683244800]`), which the server's `Array(Date)` element parser rejects (`CANNOT_PARSE_INPUT_ASSERTION_FAILED`). Container-nested `Date` values are now emitted as a quoted UTC date string (e.g. `['2023-05-05']`), the one encoding every temporal element type accepts. Note: a `Date` used inside `Array(DateTime)` / `Array(DateTime64)` is now bound at day precision (the time-of-day is dropped), since date-only is the only form `Array(Date)` accepts; scalar `Date` / `DateTime` binding is unchanged. ([#947])
 
 [#947]: https://github.com/ClickHouse/clickhouse-js/pull/947
+[#977]: https://github.com/ClickHouse/clickhouse-js/pull/977
 
 # 1.23.1
 

--- a/packages/client-web/CHANGELOG.md
+++ b/packages/client-web/CHANGELOG.md
@@ -14,9 +14,12 @@
 
 ## Bug fixes
 
+- Fixed database names from URL paths being percent-encoded twice when they contain spaces, Unicode characters, or literal percent signs. ([#977])
+
 - Fixed `Array(Date)` / `Array(Date32)` query-parameter binding (and other temporal element types nested in arrays, tuples, and maps). A JS `Date` inside a container was serialized as a bare Unix timestamp (e.g. `[1683244800]`), which the server's `Array(Date)` element parser rejects (`CANNOT_PARSE_INPUT_ASSERTION_FAILED`). Container-nested `Date` values are now emitted as a quoted UTC date string (e.g. `['2023-05-05']`), the one encoding every temporal element type accepts. Note: a `Date` used inside `Array(DateTime)` / `Array(DateTime64)` is now bound at day precision (the time-of-day is dropped), since date-only is the only form `Array(Date)` accepts; scalar `Date` / `DateTime` binding is unchanged. ([#947])
 
 [#947]: https://github.com/ClickHouse/clickhouse-js/pull/947
+[#977]: https://github.com/ClickHouse/clickhouse-js/pull/977
 
 # 1.23.1
 


### PR DESCRIPTION
## Problem

The WHATWG `URL` API exposes `pathname` in percent-encoded form. The client copied the database path directly into `config.database`, then `URLSearchParams` encoded its percent signs again when building a request:

```text
URL path:       /my%20database
Parsed before:  my%20database
Request before: database=my%2520database
```

Spaces, Unicode characters, and literal percent signs were therefore sent with the wrong database name.

## Fix

Decode the database path when converting it from its URL representation into configuration, consistent with the existing username and password handling. Request serialization then performs the single required encoding pass.

Only database names parsed from URL paths are decoded. Values supplied directly through the `database` option retain their existing semantics; a regression test pins that boundary.

The Node.js and Web clients both use the shared source through their `src/common` symlinks, and both unit suites run these tests. Their changelogs document the fix.

## Validation

- `npm run test:node:unit` (412 passed, 4 skipped)
- `npm run test:web:unit` (261 passed)
- `npm run build`
- `npm run typecheck`
- `npm run lint`
- `npm run prettier:check`