### PR TITLE
fix(rowbinary): support compiling empty Tuple() type AST

### DIFF
--- a/skills/clickhouse-js-node-rowbinary/src/readers/compile.ts
+++ b/skills/clickhouse-js-node-rowbinary/src/readers/compile.ts
@@ -162,6 +162,8 @@ function dataTypeReader(node: Node): Reader<unknown> {
       return variantReader(node);
     case "Nested":
       return nestedReader(node);
+    case "Tuple":
+      return tupleReader(node);
 
     // --- parameterized scalars ---
     case "FixedString":
@@ -211,7 +213,9 @@ function tupleReader(node: Node): Reader<unknown> {
   const readers = node.arguments.map(astToReader);
   const names = node.element_names;
   const named =
-    names.length === readers.length && names.every((n) => n.length > 0);
+    names.length > 0 &&
+    names.length === readers.length &&
+    names.every((n) => n.length > 0);
   if (named) {
     const fields: Record<string, Reader<unknown>> = {};
     for (let i = 0; i < names.length; i++) fields[names[i]!] = readers[i]!;

--- a/skills/clickhouse-js-node-rowbinary/tests/compile.test.ts
+++ b/skills/clickhouse-js-node-rowbinary/tests/compile.test.ts
@@ -111,4 +111,25 @@ describe("astToReader (AST -> Reader fold)", () => {
       /cannot build a column reader/,
     );
   });
+
+  it("folds an empty Tuple to an empty array reader", () => {
+    const read = reader("Tuple()");
+    const s = new Cursor(Buffer.alloc(0));
+    expect(read(s)).toEqual([]);
+    expect(s.pos).toBe(0);
+  });
+
+  it("folds a nested empty Tuple", () => {
+    const read = reader("Tuple(Tuple())");
+    const s = new Cursor(Buffer.alloc(0));
+    expect(read(s)).toEqual([[]]);
+    expect(s.pos).toBe(0);
+  });
+
+  it("folds an empty Tuple alongside other columns", () => {
+    const read = reader("Tuple(Tuple(), UInt8)");
+    const s = new Cursor(Buffer.from([0x05]));
+    expect(read(s)).toEqual([[], 5]);
+    expect(s.pos).toBe(1);
+  });
 });


### PR DESCRIPTION
## Summary

Resolves the AST compilation failure for empty tuples (`Tuple()`) in `@clickhouse/rowbinary`.

## Background & Root Cause

When `@clickhouse/datatype-parser` parses an empty tuple type string (such as `Tuple()` or `Tuple(Tuple())`), it returns a node with `kind: NodeKind.DataType` and `name: "Tuple"` (rather than `NodeKind.TupleDataType` which is returned for multi-element tuples like `Tuple(UInt8, String)`).

In `skills/clickhouse-js-node-rowbinary/src/readers/compile.ts`, `dataTypeReader()` did not have a handler for `case "Tuple"`. As a result, folding an empty tuple AST fell through to the default branch and threw:

```
RowBinaryTypeError: unsupported RowBinary type: Tuple
```

Additionally, `tupleReader()` previously checked `named` via `names.length === readers.length && names.every((n) => n.length > 0)`. For empty tuples where `names` and `readers` are both empty arrays (`[]`), `[].every(...)` evaluated to `true`, causing an empty tuple to be erroneously dispatched to `readTupleNamed({})` (which returns an object `{}`) instead of `readTuple([])` (which returns an array `[]`).

## Changes

1. **`compile.ts`**: Added `case "Tuple": return tupleReader(node);` to `dataTypeReader()`.
2. **`compile.ts`**: Updated `tupleReader()` so `named` requires `names.length > 0` before treating a tuple as a named object tuple.
3. **`compile.test.ts`**: Added unit tests validating that `Tuple()`, `Tuple(Tuple())`, and `Tuple(Tuple(), UInt8)` compile cleanly and decode the expected zero-byte tuples without error.

## Verification

- `npm run typecheck` in `skills/clickhouse-js-node-rowbinary` passed with 0 errors.
- `npx vitest run -t "empty Tuple" tests/compile.test.ts` passed 3/3 tests cleanly.
- `npx tsc -p tsconfig.build.json` built without errors.

Partially addresses #1000.
