### PR TITLE
Fix thrown errors in streamed value encoding

### DIFF
--- a/packages/client-node/CHANGELOG.md
+++ b/packages/client-node/CHANGELOG.md
@@ -15,8 +15,10 @@
 ## Bug fixes
 
 - Fixed `Array(Date)` / `Array(Date32)` query-parameter binding (and other temporal element types nested in arrays, tuples, and maps). A JS `Date` inside a container was serialized as a bare Unix timestamp (e.g. `[1683244800]`), which the server's `Array(Date)` element parser rejects (`CANNOT_PARSE_INPUT_ASSERTION_FAILED`). Container-nested `Date` values are now emitted as a quoted UTC date string (e.g. `['2023-05-05']`), the one encoding every temporal element type accepts. Note: a `Date` used inside `Array(DateTime)` / `Array(DateTime64)` is now bound at day precision (the time-of-day is dropped), since date-only is the only form `Array(Date)` accepts; scalar `Date` / `DateTime` binding is unchanged. ([#947])
+- (Node.js) Fixed errors thrown while serializing object-mode JSON insert streams so they are propagated through the stream error channel instead of escaping the transform callback. ([#1011])
 
 [#947]: https://github.com/ClickHouse/clickhouse-js/pull/947
+[#1011]: https://github.com/ClickHouse/clickhouse-js/pull/1011
 
 # 1.23.1
 

--- a/packages/client-node/__tests__/unit/node_values_encoder.test.ts
+++ b/packages/client-node/__tests__/unit/node_values_encoder.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 
 import type {
   DataFormat,
@@ -113,6 +113,28 @@ describe("[Node.js] ValuesEncoder", () => {
           encoded += chunk;
         }
         expect(encoded).toEqual('"foo"\n"bar"\n');
+      }
+    });
+
+    it("should propagate errors thrown while encoding JSON streams", async () => {
+      const row: Record<string, unknown> = {};
+      row.self = row;
+      const values = Stream.Readable.from([row], { objectMode: true });
+      const result = encoder.encodeValues(values, "JSONEachRow");
+      const consoleError = vi
+        .spyOn(console, "error")
+        .mockImplementation(() => undefined);
+
+      try {
+        await expect(
+          (async () => {
+            for await (const chunk of result) {
+              void chunk;
+            }
+          })(),
+        ).rejects.toThrow(TypeError);
+      } finally {
+        consoleError.mockRestore();
       }
     });
 

--- a/packages/client-node/src/utils/stream.ts
+++ b/packages/client-node/src/utils/stream.ts
@@ -51,7 +51,11 @@ export function mapStream(
   return new Stream.Transform({
     objectMode: true,
     transform(chunk, encoding, callback) {
-      callback(null, mapper(chunk));
+      try {
+        callback(null, mapper(chunk));
+      } catch (err) {
+        callback(err as Error);
+      }
     },
   });
 }


### PR DESCRIPTION
When an object-mode insert stream is encoded as JSON, a serializer error currently escapes the Transform callback. On Node 22, this can terminate the process instead of reaching the stream error channel.

**Changes**
- Pass mapper errors to the Transform callback.
- Add a regression test using circular JSON.

**Checks**
- npm --prefix packages/client-node run test:unit
- npm --prefix packages/client-node run typecheck
- npm --prefix packages/client-node run lint
- Targeted regression test under Node 22.16.0