### PR TITLE
Fix datatype parser integer name matching

### DIFF
--- a/packages/datatype-parser/CHANGELOG.md
+++ b/packages/datatype-parser/CHANGELOG.md
@@ -10,6 +10,10 @@
 
 - Node.js 18.x is no longer supported. The `engines.node` floor was raised from `>=18.0.0` to `>=20`. Node.js 20.x, 22.x, 24.x, and 26.x are supported and exercised in CI. ([#906])
 
+## Bug fixes
+
+- Fixed MySQL integer modifier detection so names that merely contain `INT`, such as `pointInPolygon`, keep their argument lists instead of being treated as integer display widths. ([#1012])
+
 # 0.1.2
 
 ## New features
@@ -18,3 +22,4 @@
 
 [#893]: https://github.com/ClickHouse/clickhouse-js/pull/893
 [#906]: https://github.com/ClickHouse/clickhouse-js/pull/906
+[#1012]: https://github.com/ClickHouse/clickhouse-js/pull/1012

--- a/packages/datatype-parser/reference-cpp-extracted-parser/src/parser.cpp
+++ b/packages/datatype-parser/reference-cpp-extracted-parser/src/parser.cpp
@@ -6,6 +6,8 @@
 #include <array>
 #include <cstdlib>
 #include <string>
+#include <string_view>
+#include <unordered_set>
 
 /// A faithful port of ClickHouse's `ParserDataType::parseImpl`
 /// (src/Parsers/ParserDataType.cpp) onto the self-contained AST in `ast.h`.
@@ -46,6 +48,17 @@ bool isWordCharOrDollar(char c)
 bool isEnumTypeUpper(const std::string & u)
 {
     return u == "ENUM" || u == "ENUM8" || u == "ENUM16";
+}
+
+bool isIntegerTypeName(const std::string & u)
+{
+    static const std::unordered_set<std::string_view> integer_type_names
+    {
+        "INT8", "INT16", "INT32", "INT64", "INT128", "INT256",
+        "UINT8", "UINT16", "UINT32", "UINT64", "UINT128", "UINT256",
+        "TINYINT", "SMALLINT", "MEDIUMINT", "INT", "INTEGER", "BIGINT", "INT1",
+    };
+    return integer_type_names.contains(u);
 }
 
 class Parser
@@ -211,7 +224,7 @@ private:
         {
             if (matchWords({"PRECISION"})) return "PRECISION";
         }
-        else if (u.find("INT") != std::string::npos)
+        else if (isIntegerTypeName(u))
         {
             /// MySQL-compatible SIGNED / UNSIGNED, optionally after `(width)`.
             if (matchWords({"SIGNED"})) return "SIGNED";

--- a/packages/datatype-parser/reference-cpp-extracted-parser/test/cases.txt
+++ b/packages/datatype-parser/reference-cpp-extracted-parser/test/cases.txt
@@ -57,6 +57,10 @@ CHAR VARYING
 INT SIGNED
 INT UNSIGNED
 
+pointInPolygon(1)
+quantileInterpolatedWeighted(1)
+intDiv(1, 2)
+
 # legacy object + dynamic
 Object('json')
 Dynamic

--- a/packages/datatype-parser/src/parser.ts
+++ b/packages/datatype-parser/src/parser.ts
@@ -62,6 +62,28 @@ function isEnumTypeUpper(u: string): boolean {
   return u === "ENUM" || u === "ENUM8" || u === "ENUM16";
 }
 
+const integerTypeNames = new Set([
+  "INT8",
+  "INT16",
+  "INT32",
+  "INT64",
+  "INT128",
+  "INT256",
+  "UINT8",
+  "UINT16",
+  "UINT32",
+  "UINT64",
+  "UINT128",
+  "UINT256",
+  "TINYINT",
+  "SMALLINT",
+  "MEDIUMINT",
+  "INT",
+  "INTEGER",
+  "BIGINT",
+  "INT1",
+]);
+
 /// Does `text` parse in FULL as a numeric literal — the TS equivalent of the
 /// C++ `strtod` (float) / `strtoull` (integer) + end-pointer check? The lexer
 /// is deliberately lenient and can hand back a half-formed lexeme such as `1e`
@@ -253,7 +275,7 @@ class Parser {
       if (this.matchWords(["VARYING"])) return "VARYING";
     } else if (u === "DOUBLE") {
       if (this.matchWords(["PRECISION"])) return "PRECISION";
-    } else if (u.indexOf("INT") !== -1) {
+    } else if (integerTypeNames.has(u)) {
       /// MySQL-compatible SIGNED / UNSIGNED, optionally after `(width)`.
       if (this.matchWords(["SIGNED"])) return "SIGNED";
       if (this.matchWords(["UNSIGNED"])) return "UNSIGNED";

--- a/packages/datatype-parser/test/parser.test.ts
+++ b/packages/datatype-parser/test/parser.test.ts
@@ -111,6 +111,28 @@ describe("parseDataType", () => {
     });
   });
 
+  it("uses exact integer names for MySQL modifiers", () => {
+    for (const typeStr of [
+      "INT(11)",
+      "INT(10) UNSIGNED",
+      "INTEGER SIGNED",
+      "TINYINT UNSIGNED",
+      "BIGINT SIGNED",
+    ]) {
+      expect(parseDataType(typeStr).ok(), `expected ${typeStr} to parse`).toBe(
+        true,
+      );
+    }
+
+    for (const typeName of ["pointInPolygon", "quantileInterpolatedWeighted"]) {
+      expect(json(`${typeName}(1)`)).toEqual({
+        type: "DataType",
+        name: typeName,
+        arguments: [{ type: "Literal", value_type: "UInt64", value: "1" }],
+      });
+    }
+  });
+
   it("compact output has no whitespace", () => {
     const r = parseDataType("Array(String)");
     expect(r.ok()).toBe(true);


### PR DESCRIPTION
The datatype parser used a substring check for INT when looking for MySQL integer modifiers. That also matched names such as pointInPolygon and could consume a single argument as a display width.

**Changes**
- Match the exact integer type names supported by ClickHouse.
- Preserve argument lists for names that only contain INT.
- Add regression coverage for valid aliases and function-like names.

**Checks**
- npm --prefix packages/datatype-parser run test
- npm --prefix packages/datatype-parser run typecheck
- npm --prefix packages/datatype-parser run lint